### PR TITLE
Fixes #162 - Added surge for deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,18 @@
   "private": false,
   "homepage": "http://skills.susi.ai/",
   "dependencies": {
+    "add-px": "^1.0.0",
     "antd": "^2.12.0",
     "babel-core": "^6.25.0",
     "babel-loader": "^7.1.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babelify": "^6.4.0",
+    "contrast": "^1.0.1",
     "dva": "^1.2.1",
     "dva-loading": "^0.2.0",
     "express": "^4.15.3",
+    "initials": "^2.1.5",
     "jquery": "latest",
     "material-ui": "^0.18.3",
     "material-ui-password-field": "latest",
@@ -25,13 +28,11 @@
     "react-router-dom": "^4.1.1",
     "react-tap-event-plugin": "^2.0.1",
     "react-url-query": "^1.2.0",
+    "surge": "^0.19.0",
     "universal-cookie": "^2.0.8",
     "watchify": "^3.9.0",
     "yarn": "^0.24.5",
-    "zxcvbn": "^4.4.2",
-    "add-px": "^1.0.0",
-    "contrast": "^1.0.1",
-    "initials": "^2.1.5"
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "react-scripts": "1.0.7"
@@ -40,7 +41,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "predeploy": "npm run build",
-    "deploy": "gh-pages -d build",
+    "deploy": "surge",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   }


### PR DESCRIPTION
Fixes issue #162 

**Changes:**
 - Added surge

**Link to deployment for testing:** http://udaytheja1.surge.sh/

**Steps to deploy**
1. npm run build
2. npm run deploy
3. In surge, put the path to `build` folder

**Screenshots for the change:** 

```
uday@uday-HP-ENVY-15-Notebook-PC:~/GSoC/susi_skill_cms$ npm run deploy

> susi@0.1.0 predeploy /home/uday/GSoC/susi_skill_cms
> npm run build


> susi@0.1.0 build /home/uday/GSoC/susi_skill_cms
> react-scripts build

Creating an optimized production build...
Skipping static resource "/home/uday/GSoC/susi_skill_cms/build/static/js/main.8fb908f1.js" (3.88 MB) - max size is 2.1 MB
Compiled successfully.

File sizes after gzip:

  1.14 MB  build/static/js/main.8fb908f1.js
  289 B    build/static/css/main.8f94f56c.css

The project was built assuming it is hosted at http://skills.susi.ai/.
You can control this with the homepage field in your package.json.

The build folder is ready to be deployed.
You may serve it with a static server:

  yarn global add serve
  serve -s build


> susi@0.1.0 deploy /home/uday/GSoC/susi_skill_cms
> surge


    Surge - surge.sh

              email: udayteja96@gmail.com
              token: *****************
       project path: /home/uday/GSoC/susi_skill_cms/build
               size: 11 files, 22.6 MB
             domain: udaytheja1.surge.sh
             upload: [====================] 100%, eta: 0.0s
   propagate on CDN: [====================] 100% 
               plan: Free
              users: udayteja96@gmail.com
         IP Address: 45.55.110.124

    Success! Project is published and running at udaytheja1.surge.sh
```
