### PR TITLE
get last login ip, time, signup time and activation status from API

### DIFF
--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -19,8 +19,8 @@ const columns = [{
         width: '25%',
     },
     {
-        title: 'Name',
-        dataIndex: 'name',
+        title: 'Activation Status',
+        dataIndex: 'confirmed',
         sorter: false,
         width: '15%',
     },
@@ -150,6 +150,10 @@ export default class ListUser extends Component {
                     let user = {
                         serialNum:++i + (page-1) *50,
                         email:data.name,
+                        confirmed:data.confirmed,
+                        signup:data.signupTime,
+                        lastLogin:data.lastLoginTime,
+                        ipLastLogin:data.lastLoginIP,
                         userRole:data.userRole
                     }
                     users.push(user);


### PR DESCRIPTION
Replaced name with 'activation status' as it was similar to email id. Fetched all other details from API reponse. https://github.com/fossasia/susi_server/pull/505 needs to be merge to see the details in the table. 