### PR TITLE
Fixes #218 linked author skills to skillPage

### DIFF
--- a/src/components/AuthorSkills/AuthorSkills.css
+++ b/src/components/AuthorSkills/AuthorSkills.css
@@ -1,0 +1,27 @@
+.effect-underline{
+  text-decoration: none;
+  display: inline-block;
+  position: relative;
+  font-family: 'Dosis', sans-serif;
+}
+.effect-underline:after {
+	content: '';
+  position: absolute;
+  left: 0;
+  display: inline-block;
+  height: 1em;
+  width: 100%;
+  border-bottom: 1px solid;
+  margin-top: 10px;
+  opacity: 0;
+	-webkit-transition: opacity 0.35s, -webkit-transform 0.35s;
+	transition: opacity 0.35s, transform 0.35s;
+	-webkit-transform: scale(0,1);
+	transform: scale(0,1);
+}
+
+.effect-underline:hover:after {
+  opacity: 1;
+	-webkit-transform: scale(1);
+	transform: scale(1);
+}

--- a/src/components/AuthorSkills/AuthorSkills.js
+++ b/src/components/AuthorSkills/AuthorSkills.js
@@ -6,6 +6,7 @@ import * as $ from "jquery";
 import Img from 'react-image';
 import CircleImage from "../CircleImage/CircleImage";
 import Close from 'material-ui/svg-icons/navigation/close';
+import './AuthorSkills.css';
 import {
   Table,
   TableBody,
@@ -76,7 +77,8 @@ export default class AuthorSkills extends Component {
                     <TableRow>
                       <TableRowColumn>
                         <div>
-                          <a href={skillURL} >
+                          <a
+                            href={skillURL} >
                             <Img
                               style={imageStyle}
                               src={[
@@ -86,7 +88,11 @@ export default class AuthorSkills extends Component {
                               unloader={<CircleImage name={name} size="40"/>}
                           />
                         </a>
+                          <a
+                            href={skillURL}
+                            className="effect-underline" >
                           {name}
+                        </a>
                         </div>
                       </TableRowColumn>
                       <TableRowColumn>{parse[6]}</TableRowColumn>

--- a/src/components/AuthorSkills/AuthorSkills.js
+++ b/src/components/AuthorSkills/AuthorSkills.js
@@ -70,18 +70,22 @@ export default class AuthorSkills extends Component {
                     let image1 = image + '.png';
                     let image2 = image + '.jpg';
 
+                  let skillURL = 'http://skills.susi.ai/' + parse[6] + '/' + parse[8].split('.')[0] + '/' + parse[7];
+
                   return (
                     <TableRow>
                       <TableRowColumn>
                         <div>
-                          <Img
-                            style={imageStyle}
-                            src={[
-                              image1,
-                              image2
-                            ]}
-                            unloader={<CircleImage name={name} size="40"/>}
-                        />
+                          <a href={skillURL} >
+                            <Img
+                              style={imageStyle}
+                              src={[
+                                image1,
+                                image2
+                              ]}
+                              unloader={<CircleImage name={name} size="40"/>}
+                          />
+                        </a>
                           {name}
                         </div>
                       </TableRowColumn>


### PR DESCRIPTION
Fixes #218 
Changes: Linked author skills to skill page. Click on the image and it will link you to skill page

Link to deployment for testing: http://skilllink.surge.sh/

@dynamitechetan @rishiraj824 @isuruAb @saurabhjn76 @uday96 Please Review
Thanks
