### PR TITLE
confirmed status visible

### DIFF
--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -156,6 +156,14 @@ export default class ListUser extends Component {
                         ipLastLogin:data.lastLoginIP,
                         userRole:data.userRole
                     };
+                  
+                    if(user.confirmed) {
+                        user.confirmed = "Activated"
+                    }
+                    else {
+                        user.confirmed = "Not Activated"
+                    }
+                  
                     users.push(user);
                     return 1
                 });
@@ -187,3 +195,4 @@ export default class ListUser extends Component {
         );
     }
 }
+    


### PR DESCRIPTION
fixes #246 If a user has confirmed their id, it will show activated, else not activated.
![status](https://user-images.githubusercontent.com/14837478/29488329-22c1b48c-8526-11e7-9eec-ba3c226106e8.png)
