### PR TITLE
removed unnecessary skill editing link label

### DIFF
--- a/src/components/SkillEditor/SkillEditor.js
+++ b/src/components/SkillEditor/SkillEditor.js
@@ -378,7 +378,6 @@ export default class Container extends React.Component {
                 <StaticAppBar {...this.props} />
                 <div style={styles.home}>
                     <Paper style={style} zDepth={1}>
-                        <div>Currently Editing : <h3>{this.state.skillUrl}</h3></div>
                         <div style={styles.center}>
                             <div style={styles.dropdownDiv}>
                                 <SelectField


### PR DESCRIPTION
fixes #263  

Changes: Removed the link div

Link to deployment for testing:http://scintillating-garden.surge.sh/

Screenshots for the change: 
![image](https://user-images.githubusercontent.com/9781788/29566927-30970eb4-8769-11e7-81d7-271343643ed6.png)
