### PR TITLE
Fixes #264 - Clicking on "Versions" does not bring up the usual editing window and no save button

### DIFF
--- a/src/components/SkillVersion/SkillVersion.js
+++ b/src/components/SkillVersion/SkillVersion.js
@@ -210,8 +210,8 @@ class SkillVersion extends Component {
           <Link to={{
               pathname: '/'+this.state.skillMeta.groupValue+
                         '/'+this.state.skillMeta.skillName+
-                        '/version/'+this.state.skillMeta.languageValue+
-                        '/'+commit.commitID,
+                        '/edit/'+this.state.skillMeta.languageValue+
+                        '/'+commit.commitID
           }}>
             <abbr title={commit.commitDate}>{commit.commitDate}</abbr>
           </Link>

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ class App extends React.Component {
                 <MuiThemeProvider>
                     <Switch>
                         <Route exact path="/:category/:skill/edit/:lang" component={SkillEditor} />
+                        <Route exact path="/:category/:skill/edit/:lang/:commit" component={SkillEditor}/>
                         <Route exact path="/admin" component={Admin}/>
                         <Route path="/listUser" component={ListUser}/>
                         <Route exact path="/:category/:skill/:lang" component={SkillListing}/>
@@ -35,7 +36,6 @@ class App extends React.Component {
                         <Route exact path="/logout" component={Logout} />
                         <Route exact path="/skillCreator" component={CreateSkill}/>
                         <Route exact path="/:category/:skill/versions/:lang" component={SkillVersion}/>
-                        <Route exact path="/:category/:skill/version/:lang/:commit" component={SkillHistory}/>
                         <Route exact path="/:category/:skill/compare/:lang/:oldid/:recentid" component={SkillHistory}/>
                         <Route exact path="/:category/:skill/edit/:lang/:latestid/:revertid" component={SkillRollBack}/>
                         <Route exact path="/" component={BrowseSkill} />


### PR DESCRIPTION
Fixes issue #264 

Changes: 
- [x] Added a new "notifications area" on top
- [x] Using the same skill editor as on the "edit skill page" 
- [x] Included the top bar.
- [x] Included the bottom bar
- [x] Added a "cancel" button, that cancels the current changes and returns the user to the skill page
- [x] Implement direct URLs

Link to deployment for testing:
http://susi-cms.surge.sh/Knowledge/language/edit/en/0db81a5abdc015fd241125148a82dcec63d79127

Screenshots for the change: 
![screencapture-localhost-3003-knowledge-sentiment_analysis-edit-en-108631fdbd0b463c811bfb9ff3ff7ee1785c55fd-1503523709084](https://user-images.githubusercontent.com/11540785/29639371-25cda00a-8878-11e7-8ae5-b66e854c1da4.png)

