### PR TITLE
Fixes #280 - Remove scrollbars and fix top bar menu pop over

### DIFF
--- a/src/components/SkillHistory/SkillHistory.js
+++ b/src/components/SkillHistory/SkillHistory.js
@@ -190,6 +190,8 @@ class SkillHistory extends Component {
                 value={this.state.commitData[0].code}
                 showPrintMargin={false}
                 name="skill_code_editor"
+                scrollPastEnd={false}
+                wrapEnabled={true}
                 editorProps={{$blockScrolling: true}}
             />
             </div>
@@ -212,6 +214,8 @@ class SkillHistory extends Component {
                     value={this.state.commitData[0].code}
                     showPrintMargin={false}
                     name="skill_code_editor"
+                    scrollPastEnd={false}
+                    wrapEnabled={true}
                     editorProps={{$blockScrolling: true}}
                 />
                 </div>
@@ -239,6 +243,8 @@ class SkillHistory extends Component {
                     value={this.state.commitData[1].code}
                     showPrintMargin={false}
                     name="skill_code_editor"
+                    scrollPastEnd={false}
+                    wrapEnabled={true}
                     editorProps={{$blockScrolling: true}}
                 />
                 </div>

--- a/src/components/SkillRollBack/SkillRollBack.js
+++ b/src/components/SkillRollBack/SkillRollBack.js
@@ -254,6 +254,8 @@ class SkillRollBack extends Component {
                   value={this.state.commitData[0].code}
                   showPrintMargin={false}
                   name="skill_code_editor"
+                  scrollPastEnd={false}
+                  wrapEnabled={true}
                   editorProps={{$blockScrolling: true}}
               />
               </div>
@@ -272,6 +274,8 @@ class SkillRollBack extends Component {
                   value={this.state.commitData[1].code}
                   showPrintMargin={false}
                   name="skill_code_editor"
+                  scrollPastEnd={false}
+                  wrapEnabled={true}
                   editorProps={{$blockScrolling: true}}
               />
               </div>
@@ -302,6 +306,8 @@ class SkillRollBack extends Component {
                     showPrintMargin={false}
                     name="skill_code_editor"
                     onChange={this.updateCode}
+                    scrollPastEnd={false}
+                    wrapEnabled={true}
                     editorProps={{$blockScrolling: true}}
                 />
               </div>

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -60,7 +60,7 @@ class StaticAppBar extends Component {
             showOptions: false,
             showAdmin: false,
             anchorEl: null,
-            leftGap: '0px'            
+            leftGap: '0px'
         }
     }
 
@@ -207,7 +207,7 @@ class StaticAppBar extends Component {
             cursor: 'pointer'
         };
         var leftGap = this.state.leftGap;
-        
+
         const bodyStyle = {
             'padding': 0,
             textAlign: 'center'
@@ -232,8 +232,8 @@ class StaticAppBar extends Component {
                         style={{ float: 'left', position: 'relative', marginTop: '46px', marginLeft: leftGap }}
                         open={this.state.showOptions}
                         anchorEl={this.state.anchorEl}
-                        anchorOrigin={{ horizontal: 'left', vertical: 'top' }}
-                        targetOrigin={{ horizontal: 'left', vertical: 'top' }}
+                        anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+                        targetOrigin={{ horizontal: 'right', vertical: 'top' }}
                         onRequestClose={this.closeOptions}
                     >
                         <TopRightMenuItems />


### PR DESCRIPTION
Fixes issue #280 

**Changes:**
 - Removed overscrolling in editors in skillHistory and skillRollBack Components
 - Changed top bar drop down menu direction from left to right similar to webchat

**Link to deployment for testing:**  http://topbar.surge.sh/
