### PR TITLE
Show all skills #333

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -57,6 +57,10 @@ export default class BrowseSkill extends React.Component {
             success: function (data) {
                 let skills = data.filteredData.map((skill,i)=>{
                     let skill_name, examples, image, description;
+                    if(skill.skill_name == null)
+                    {
+                        return 0;
+                    }
                     let el = skill.skill_name.replace(/\s+/g, '_').toLowerCase();
                     if (skill.skill_name) {
                         skill_name = skill.skill_name;

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -67,7 +67,7 @@ class StaticAppBar extends Component {
     }
 
     handleScroll = (event) => {
-        let scrollTop = event.srcElement.body.scrollTop,
+        let scrollTop = event.pageY || event.target.body.scrollTop,
             itemTranslate = scrollTop > 60;
         if (itemTranslate) {
             this.closeOptions();


### PR DESCRIPTION
Fixes #333 

Because of 'null' values in this [api link](https://api.susi.ai/cms/getSkillList.json?applyFilter=true&filter_name=ascending&filter_type=lexicographical) it was giving error. So I fixed by checking if the value is null or not. After this the homepage is viewed fine as shown in image.

Also in case of firefox if we try to scroll down then it was giving error as shown in image below:
It was giving error in firefox only but in case of Chromium there was no error while scrolling. So I changed how scrollTop finds value from browser.

Sorry for my previous PR I messed that up a little but while squashing 2 commits.

![screenshot from 2017-09-19 15-55-11](https://user-images.githubusercontent.com/9320644/30588363-03e2b19c-9d54-11e7-9b52-99be3d52d680.png)

![screenshot from 2017-09-19 15-54-51](https://user-images.githubusercontent.com/9320644/30588373-12a7b48e-9d54-11e7-89ad-246373676d4d.png)
