### PR TITLE
Redirect to skill page after successful edit - fixes issue 338

### DIFF
--- a/src/components/SkillEditor/SkillEditor.js
+++ b/src/components/SkillEditor/SkillEditor.js
@@ -541,6 +541,11 @@ class SkillEditor extends Component {
                         description: 'Your Skill has been uploaded to the server',
                         icon: <Icon type='check-circle' style={{ color: '#00C853' }} />
                     });
+                    setTimeout(() => {
+                    this.props.history.push('/'+this.state.groupValue+
+                                          '/'+this.state.expertValue+
+                                          '/'+this.state.languageValue);
+                     }, 1000);
                 }
                 else {
                     this.setState({


### PR DESCRIPTION
Fixes #338 
Redirect to skill page on successful skill update.
Changes: 

- Programmatically redirected to the skill page

Link to deployment for testing: http://shaggy-thing.surge.sh/

Screenshots for the change: 
![screen shot 2017-09-23 at 5 16 34 am](https://user-images.githubusercontent.com/11137394/30767854-737042be-a01e-11e7-8075-47b064299d1a.png)

