### PR TITLE
Add cancel button on create new skill page

### DIFF
--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -479,6 +479,7 @@ export default class CreateSkill extends React.Component {
                                     onChange={this.handleCommitMessageChange}
                                 />
                                 <RaisedButton label='Save' backgroundColor={colors.header} labelColor='#fff' style={{marginLeft:10}}  onTouchTap={this.saveClick} />
+				<a href="http://skills.susi.ai/"><RaisedButton label='Cancel' backgroundColor={colors.header} labelColor='#fff' style={{marginLeft:10}} /></a>
                             </Paper>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #398 
Changes: Added Cancel button on Add skill page

Screenshots for the change:
![cancel1](https://user-images.githubusercontent.com/30981465/37109097-fe3194da-225e-11e8-9bfd-0a2e67d0cd5f.png)
