### PR TITLE
Improve CSS of filter bar on browse skills page

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -307,7 +307,7 @@ export default class BrowseSkill extends React.Component {
                                 value={this.state.languageValue}
                                 floatingLabelFixed={false}
                                 onChange={this.handleLanguageChange}
-                                style={styles.select}
+                                style={styles.selection}
                                 listStyle={{
                                     top: '100px'
                                 }}
@@ -325,6 +325,7 @@ export default class BrowseSkill extends React.Component {
                                 value={this.state.filter}
                                 floatingLabelFixed={false}
                                 onChange={this.handleFilterChange}
+                                style={styles.selection}
                                 className='select'
                                 listStyle={{
                                     top: '100px'
@@ -345,7 +346,8 @@ export default class BrowseSkill extends React.Component {
                             key={'&applyFilter=true&filter_name=descending&filter_type=lexicographical'}
                             primaryText={'Z-A'} label={'Name'} />
                             </SelectField>
-                            <div>
+
+                            <div style={styles.newSkillBtn}>
                                 <Link to='/skillCreator'>
                                     <FloatingActionButton data-tip='Create Skill'
                                         backgroundColor={colors.fabButton}

--- a/src/components/BrowseSkill/SkillStyle.js
+++ b/src/components/BrowseSkill/SkillStyle.js
@@ -97,6 +97,9 @@ const styles = {
         margin: '0px 10px',
         width: '300px'
     },
+    newSkillBtn: {
+        padding: '10px 0px 10px 10px'
+    },
     titleStyle:{
         textAlign: 'left',
         fontStyle: 'italic',


### PR DESCRIPTION
Fixes #395 

Surge Deployment Link: http://famous-frog.surge.sh/

Changes with Screenshots:

- I made the size of all three filter options same.

Before-
<img width="1391" alt="screen shot 2018-03-10 at 8 32 07 pm" src="https://user-images.githubusercontent.com/31174685/37243601-547a8fdc-24a2-11e8-856a-47f639ce2df8.png">
After-
<img width="1393" alt="screen shot 2018-03-10 at 8 32 18 pm" src="https://user-images.githubusercontent.com/31174685/37243602-5e4894dc-24a2-11e8-8a7d-3da5a3fcf3c7.png">

- Then provided some padding. It looked congested earlier.

Before-
<img width="351" alt="screen shot 2018-03-10 at 8 32 30 pm" src="https://user-images.githubusercontent.com/31174685/37243614-9e92f69a-24a2-11e8-8400-7e58cb1ae6f0.png">
After-
<img width="350" alt="screen shot 2018-03-10 at 8 32 37 pm" src="https://user-images.githubusercontent.com/31174685/37243615-a13be44c-24a2-11e8-9eb5-2727da134752.png">


