### PR TITLE
Fixes #421: Modify languageNativeName to languageName in drop-down

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -114,11 +114,11 @@ export default class BrowseSkill extends React.Component {
                     data.sort();
                     this.setState({ languages: data });
                     for (let i = 0; i < data.length; i++) {
-                        if (ISO6391.getNativeName(data[i])) {
+                        if (ISO6391.getName(data[i])) {
                             languages.push(<MenuItem
                                 value={data[i]}
                                 key={data[i]}
-                                primaryText={ISO6391.getNativeName(data[i])} />);
+                                primaryText={ISO6391.getName(data[i])} />);
                         }
                         else {
                             languages.push(<MenuItem value={data[i]}


### PR DESCRIPTION
Fixes #421 

Changes: 
The language Native Names were changed to their general Names so that no empty MenuItem field exists

Surge Deployment Link: [http://lazy-road.surge.sh](http://lazy-road.surge.sh)

Screenshots for the change:
![deepinscreenshot_select-area_20180506172831](https://user-images.githubusercontent.com/12656846/39673048-eaf1b198-5152-11e8-89ca-b50509d30a57.png)
You can see the missing languages appear