### PR TITLE
Fixes #435: Add surge deployment link to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,6 +2,6 @@ Fixes #[Add issue number here. If you do not solve the issue entirely, please ch
 
 Changes: [Add here what changes were made in this issue and if possible provide links.]
 
-Surge Deployment Link: [Add here the link where you changes can be seen]
+Surge Deployment Link: https://pr-<PR Number>-fossasia-susi-sill-cms.surge.sh
 
 Screenshots for the change:


### PR DESCRIPTION
Fixes #435 

Changes: Add surge deployment link to PR template since pr deployments are working now.