### PR TITLE
Prevents page reload when Skills option is selected in the Menu

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -41,11 +41,12 @@ let TopRightMenuItems = (props) => (
             rightIcon={<Chat />}>
             Chat
         </MenuItem>
-        <MenuItem
-            href='http://skills.susi.ai/'
-            rightIcon={<SKillIcon />}>
-            Skills
-        </MenuItem>
+        <Link to = "/">
+          <MenuItem
+              rightIcon={<SKillIcon />}>
+              Skills
+          </MenuItem>
+        </Link>
         <MenuItem primaryText='Settings'
             onTouchTap={this.handleClose}
             containerElement={<Link to='/settings' />}


### PR DESCRIPTION
Fixes #441 

**Changes:** Routes the page back to the main Skills page instead of reloading the entire site when the Skills option is clicked in the Menu. This also keeps it consistent with how "Chat" option is handled in https://chat.susi.ai.