### PR TITLE
Adds Back button in the Settings page

### DIFF
--- a/src/components/Settings/Settings.js
+++ b/src/components/Settings/Settings.js
@@ -9,6 +9,7 @@ import RaisedButton from 'material-ui/RaisedButton';
 import { Paper } from 'material-ui';
 import colors from '../../Utils/colors';
 import urls from '../../Utils/urls'
+import { Link } from 'react-router-dom'
 const cookies = new Cookies();
 let BASE_URL = urls.API_URL;
 
@@ -145,7 +146,16 @@ class Settings extends React.Component {
                 disabled={!changed}
                 labelColor='#fff'
                 onClick={this.handleSubmit}
+                style={{margin: '16px'}}
               />
+              <Link to = "/">
+                <RaisedButton
+                  label='Back'
+                  backgroundColor={colors.header}
+                  labelColor='#fff'
+                  style={{margin: '16px'}}
+                />
+              </Link>
               </Paper>
               </div>
             </div>


### PR DESCRIPTION
Fixes #445 

**Changes:** Adds a Back button in the Settings page to go to the main page of https://skills.susi.ai.

**Screenshots for the change:**
![savebuttoninsettings](https://user-images.githubusercontent.com/31135861/39955509-8ddbb1a8-55ed-11e8-895a-3a00b9e0782f.png)

