### PR TITLE
Who is logged in appears on top of page

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -221,6 +221,14 @@ class StaticAppBar extends Component {
         let TopRightMenu = (props) => (
             <div onScroll={this.handleScroll}>
                 <div>
+                    {cookies.get('loggedIn') ?
+                        (<label
+                            style={{color: 'white', fontSize: '16px', verticalAlign:'super'}}>
+                            {cookies.get('emailId')}
+                            </label>) :
+                        (<label>
+                            </label>)
+                    }
                     <IconMenu
                         {...props}
                         iconButtonElement={


### PR DESCRIPTION
Fixes #464 [No details about logged in user]

Changes: Added the email of the logged in user at the top of the page.

Surge Deployment Link: http://susi--cms.surge.sh/

Screenshots for the change:
![image](https://user-images.githubusercontent.com/10573038/40251603-6400f8c0-5af7-11e8-9ecf-f3b91f8b7c80.png)

