### PR TITLE
Fixes #466: Add relevant timestamps in skill details

### DIFF
--- a/src/components/SkillPage/SkillListing.css
+++ b/src/components/SkillPage/SkillListing.css
@@ -102,6 +102,11 @@ abbr[title] {
     width:auto;
 }
 
+.skill {
+  display: flex;
+  flex-direction: column;
+}
+
 @media only screen and (min-width: 0px) and (max-width: 768px){
 
   .avatar-img {

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -50,11 +50,13 @@ class SkillListing extends Component {
             skill_name: '',
             positive_rating: 0,
             negative_rating: 0,
+            last_modified_time: '',
+            last_access_time: '',
             showAuthorSkills: false,
             dataReceived: false,
             imgUrl: null,
             commits: [],
-            commitsChecked: [],
+            commitsChecked: []
         };
 
         let clickedSkill = this.props.location.pathname.split('/')[2];
@@ -172,6 +174,10 @@ class SkillListing extends Component {
             });
         }
         this.setState({
+            last_modified_time: skillData['lastModifiedTime: '],
+            last_access_time: skillData['lastAccessTime: ']
+        })
+        this.setState({
             dataReceived: true
         });
     };
@@ -186,6 +192,31 @@ class SkillListing extends Component {
     closeAuthorSkills = () => {
         this.setState({ showAuthorSkills: false });
     };
+
+    parseDate = dtstr => {
+        // replace anything but numbers by spaces
+        dtstr = dtstr.replace(/\D/g,' ');
+        // trim any hanging white space
+        dtstr = dtstr.replace(/\s+$/,'');
+        // split on space
+        var dtcomps = dtstr.split(' ');
+        // not all ISO 8601 dates can convert, as is
+        // unless month and date specified, invalid
+        if (dtcomps.length < 3) {
+            return 'Invalid date';
+        }
+        // if time not provided, set to zero
+        if (dtcomps.length < 4) {
+            dtcomps[3] = 0;
+            dtcomps[4] = 0;
+            dtcomps[5] = 0;
+        }
+        // modify month between 1 based ISO 8601 and zero based Date
+        dtcomps[1]--;
+        const convdt = new
+        Date(Date.UTC(dtcomps[0],dtcomps[1],dtcomps[2],dtcomps[3],dtcomps[4],dtcomps[5]));
+        return convdt.toUTCString();
+    }
 
     render() {
 
@@ -279,8 +310,8 @@ class SkillListing extends Component {
                         </h1>
                         <h4>
                             author: <span style={authorStyle}
-                                          onClick={this.openAuthorSkills}>
-                                          {this.state.author}
+                                      onClick={this.openAuthorSkills}>
+                                      {this.state.author}
                                     </span>
                         </h4>
                         <div className='avatar-meta margin-b-md'>
@@ -315,23 +346,34 @@ class SkillListing extends Component {
                         <h1 className='title'>
                             Skill Details
                         </h1>
-                        <ul>
-                            {this.state.dynamic_content ?
-                                <li>The Skill Contains content Dynamic Content
-                                    that is updated real-time based on inputs
-                                    from the User.</li> :
-                                <li>Skill details are not available yet.</li>}
+                        <div>
+                            <ul>
+                                {this.state.dynamic_content ?
+                                    <li>The Skill Contains content Dynamic Content
+                                        that is updated real-time based on inputs
+                                        from the User.</li> :
+                                    <li>Skill details are not available yet.</li>}
 
-                            {this.state.terms_of_use == null ? '' :
-                              (<li><a href={this.state.terms_of_use}
-                                      target='_blank'
-                                      rel='noopener noreferrer'>Term & Condition</a></li>)}
+                                {this.state.terms_of_use == null ? '' :
+                                  (<li><a href={this.state.terms_of_use}
+                                          target='_blank'
+                                          rel='noopener noreferrer'>Term & Condition</a></li>)}
 
-                            {this.state.terms_of_use == null ? '' :
-                              (<li><a href={this.state.developer_privacy_policy}
-                                      target='_blank'
-                                      rel='noopener noreferrer'>Developer Privacy Policy</a></li>)}
-                        </ul>
+                                {this.state.terms_of_use == null ? '' :
+                                  (<li><a href={this.state.developer_privacy_policy}
+                                          target='_blank'
+                                          rel='noopener noreferrer'>Developer Privacy Policy</a></li>)}
+                            </ul>
+                        </div>
+                        <div>
+                            Last accessed at -
+                                {` ${this.parseDate(this.state.last_access_time)}`}
+                        </div>
+                        <div>
+                            Last modified at -
+                                {` ${this.parseDate(this.state.last_modified_time)}`}
+                        </div>
+
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #466 

Changes: Display timestamps related to skill on skill page

Surge Deployment Link: https://pr-468-fossasia-susi-sill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/40275370-5ee7e28a-5c0b-11e8-8cb4-d60882da338f.png)

