### PR TITLE
fix #477 - create a basic chatbot web plugin (part 1)

### DIFF
--- a/src/components/ChatbotPlugin/ChatbotPlugin.css
+++ b/src/components/ChatbotPlugin/ChatbotPlugin.css
@@ -1,0 +1,31 @@
+.code-box {
+	position: relative;
+	background: #d3d3d3;
+	border-radius: .4em;
+	display: inline-block;
+	padding:10px 20px;
+	-webkit-box-shadow: 0 3px 2px 0 rgba(0,0,0,.1);
+    box-shadow: 0 3px 2px 0 rgba(0,0,0,.1);
+	margin-bottom: 5px;
+}
+
+.code-box:after {
+	content: '';
+	position: absolute;
+	top: 0;
+	left: 50%;
+	width: 0;
+	height: 0;
+	border: 15px solid transparent;
+	border-bottom-color: #d3d3d3;
+	border-top: 0;
+	margin-left: -15px;
+	margin-top: -15px;
+}
+.code-wrap{
+	transition: all 0.3s ease-in;
+	display: none;
+}
+.code-wrap.show{
+	display: block;
+}

--- a/src/components/ChatbotPlugin/ChatbotPlugin.js
+++ b/src/components/ChatbotPlugin/ChatbotPlugin.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
+import RaisedButton from 'material-ui/RaisedButton';
+import { Paper } from 'material-ui';
+import colors from '../../Utils/colors';
+import './ChatbotPlugin.css';
+
+class ChatbotPlugin extends React.Component {
+
+    constructor(props){
+        super(props);
+        this.state = {
+            showCode:false
+        }
+    }
+
+    handleClickGenerate = () =>{
+        this.setState({showCode:true});
+    }
+
+    render() {
+        const style = {
+          width: '100%',
+          padding: '30px',
+          textAlign: 'center',
+          marginTop:'20px'
+        };
+        return(
+          <div>
+            <StaticAppBar {...this.props} />
+            <div style={styles.home}>
+              <Paper style={style} zDepth={1}>
+                <h1 style={styles.bg}>Integrate SUSI chat in your website</h1>
+                <br/>
+                <RaisedButton
+                  label='Generate JavaScript code'
+                  backgroundColor={colors.header}
+                  labelColor='#fff'
+                  onClick={this.handleClickGenerate}
+                />
+                <br/><br/>
+                <div className={'code-wrap '+(this.state.showCode?'show':'hide')}>
+                  <div className="code-box">
+                    <code>
+                      &lt;script type=&quot;text/javascript&quot; src=&quot;https://skills.susi.ai/susi-chatbot.js&quot;&gt;&lt;/script&gt;
+                    </code>
+                  </div>
+                  <h4>Paste the above code just above <i>&lt;/body&gt;</i>
+                  tag in your website</h4>
+                </div>
+              </Paper>
+            </div>
+          </div>
+       )
+    }
+}
+
+const styles = {
+    home: {
+        width: '100%',
+        padding: '40px 30px 30px',
+    },
+    bg: {
+        textAlign: 'center',
+        padding: '30px',
+    }
+};
+
+ChatbotPlugin.propTypes = {
+};
+
+export default ChatbotPlugin;

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -13,6 +13,7 @@ import IconMenu from 'material-ui/IconMenu';
 import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import Popover from 'material-ui/Popover';
 import Exit from 'material-ui/svg-icons/action/exit-to-app';
+import Extension from 'material-ui/svg-icons/action/extension';
 import LoginIcon from 'material-ui/svg-icons/action/account-circle';
 import Info from 'material-ui/svg-icons/action/info';
 import Chat from 'material-ui/svg-icons/communication/chat';
@@ -145,7 +146,7 @@ class StaticAppBar extends Component {
     showOptions = (event) => {
         var p = $('#rightIconButton').width();
         var screenWidth = $(window).width();
-        this.setState({ leftGap: ((screenWidth - p) / 2) + p - 130 })
+        this.setState({ leftGap: ((screenWidth - p) / 2) + p - (cookies.get('loggedIn')?170:130) })
         event.preventDefault();
         this.setState({
             showOptions: true,
@@ -251,6 +252,12 @@ class StaticAppBar extends Component {
                                     console.log('Admin page allowed ' + cookies.get('showAdmin'))
                                 )
 
+                        }
+                        {cookies.get('loggedIn') ?
+                            (<MenuItem primaryText='Chatbot Plugin'
+                                containerElement={<Link to='/chatbot' />}
+                                rightIcon={<Extension />} />) :
+                            null
                         }
                         {cookies.get('loggedIn') ?
                             (<MenuItem primaryText='Logout'

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import { BrowserRouter as Router, Route} from 'react-router-dom';
 import NotFound from './components/NotFound/NotFound';
 import Admin from './components/Admin/Admin'
 import Settings from './components/Settings/Settings';
+import ChatbotPlugin from './components/ChatbotPlugin/ChatbotPlugin';
 import Switch from 'react-router-dom/es/Switch';
 import BrowseSkill from './components/BrowseSkill/BrowseSkill';
 import injectTapEventPlugin from 'react-tap-event-plugin';
@@ -37,6 +38,7 @@ class App extends React.Component {
                         <Route path='/listUser' component={ListUser}/>
                         <Route exact path='/:category/:skill/:lang' component={SkillListing}/>
                         <Route exact path='/settings' component={Settings}/>
+                        <Route exact path='/chatbot' component={ChatbotPlugin}/>
                         <Route exact path='/logout' component={Logout} />
                         <Route exact path='/skillCreator' component={CreateSkill}/>
                         <Route exact path='/:category/:skill/versions/:lang' component={SkillVersion}/>


### PR DESCRIPTION
Fixes #477 

Changes: 
- Add a new page `/chatbot`. This page currently enables the user to generate the code which they can put in their website to integrate susi chat plugin. The page will be visible only if you are logged in. (more settings such as customizing the UI of the chatbot will come afterwards in this page). The generated link is currently static.

Surge Deployment Link: http://skills-susi-webchat.surge.sh (after PR #479 is merged too)

**Screenshot for the change:**
![image](https://user-images.githubusercontent.com/17807257/40378194-6dda96e6-5e10-11e8-901e-8ad9b5b9d185.png)
![image](https://user-images.githubusercontent.com/17807257/40378485-504200f0-5e11-11e8-8fb5-c54e38993dd5.png)

**For testing:**
For testing, please paste the following code in any html file of your website:
```
<script type="text/javascript" src="http://skills-susi-webchat.surge.sh/susi-chatbot.js"></script>
```
**Live version** of the embedded bot can be found at: http://susi-plugin-demo.surge.sh/

Result should be:
![image](https://user-images.githubusercontent.com/17807257/40385135-4a5ee196-5e23-11e8-9971-b306ff5febef.png)
![image](https://user-images.githubusercontent.com/17807257/40385176-622c33f0-5e23-11e8-97e7-a5599f14627c.png)



@DNS-404 has send a PR (part 2) which will complete this feature by adding the javascript, css and icon files.
