### PR TITLE
Fixes #493: Fix popover position below the hamburger menu

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -244,7 +244,7 @@ class StaticAppBar extends Component {
                     </IconMenu>
                     <Popover
                         {...props}
-                        style={{ float: 'left', position: 'relative', marginTop: '46px', marginLeft: leftGap }}
+                        style={{ float: 'right', position: 'relative', marginTop: '46px', marginLeft: leftGap }}
                         open={this.state.showOptions}
                         anchorEl={this.state.anchorEl}
                         anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}


### PR DESCRIPTION
Fixes #493 

Changes: Make the popover menu float to the right

Surge Deployment Link: https://pr-501-fossasia-susi-sill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/40536047-84b9efe6-6028-11e8-8583-818565cbd532.png)
