### PR TITLE
Reset Search Query when any Category is selected

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -59,7 +59,10 @@ export default class BrowseSkill extends React.Component {
     };
 
     handleGroupChange = (event, index, value) => {
-        this.setState({groupValue: value}, function () {
+        this.setState({
+          groupValue: value,
+          searchQuery: ''
+        }, function () {
         // console.log(this.state);
         this.loadCards();
         });


### PR DESCRIPTION
Fixes #516

Changes: Resetted the Search Query if any Category is selected so that all Skills of that Category are displayed.

Surge Deployment Link: https://pr-517-fossasia-susi-sill-cms.surge.sh
