### PR TITLE
Fixed skill rating URL

### DIFF
--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -214,7 +214,7 @@ class SkillListing extends Component {
 
     changeRating = (newRating) => {
 
-        let baseUrl = urls.API_URL + 'cms/fiveStarRateSkill.json';
+        let baseUrl = urls.API_URL + '/cms/fiveStarRateSkill.json';
         let skillRatingUrl = `${urls.API_URL}/cms/getSkillRating.json`
 
         let modelValue = 'general';


### PR DESCRIPTION
Fixes 
Missing slash in the API URL #521 

Changes:
Added slash to the API URL.

Surge Deployment Link: http://susi--cms.surge.sh/

Screenshots for the change:
NA