### PR TITLE
Fixes #499: Display a message when no ratings for skill are present

### DIFF
--- a/src/components/SkillPage/SkillListing.css
+++ b/src/components/SkillPage/SkillListing.css
@@ -171,3 +171,10 @@ abbr[title] {
 .large-text {
   font-size: 48px;
 }
+
+.ratings-default-message {
+  margin: 10px;
+  display: flex;
+  justify-content: center;
+  padding-bottom: 10px;
+}

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -64,7 +64,8 @@ class SkillListing extends Component {
             commitsChecked: [],
             avg_rating: '',
             skill_ratings: [],
-            rating : 0
+            rating : 0,
+            total_reviews: 0
         };
 
         let clickedSkill = this.props.location.pathname.split('/')[2];
@@ -165,15 +166,16 @@ class SkillListing extends Component {
     };
 
     saveSkillRatings = (skill_ratings) => {
-        // Sample data
-        const ratings_data = [{name: '5 ⭐', value: skill_ratings.five_star || 0},
-              {name: '4 ⭐', value: skill_ratings.four_star || 0},
-              {name: '3 ⭐', value: skill_ratings.three_star || 0},
-              {name: '2 ⭐', value: skill_ratings.two_star || 0},
-              {name: '1 ⭐', value: skill_ratings.one_star || 0}];
+        const ratings_data = [{name: '5 ⭐', value: skill_ratings.stars.five_star || 0},
+              {name: '4 ⭐', value: skill_ratings.stars.four_star || 0},
+              {name: '3 ⭐', value: skill_ratings.stars.three_star || 0},
+              {name: '2 ⭐', value: skill_ratings.stars.two_star || 0},
+              {name: '1 ⭐', value: skill_ratings.stars.one_star || 0}];
+        console.log(skill_ratings);
         this.setState({
             skill_ratings: ratings_data,
-            avg_rating: skill_ratings.avg_star
+            avg_rating: skill_ratings.avg_star,
+            total_reviews: parseInt(skill_ratings.stars.total_star, 10)
         })
     }
 
@@ -469,39 +471,43 @@ class SkillListing extends Component {
                             :
                             null
                         }
-                        <div className="ratings-section">
-                            <div className="average">
-                                Average Rating
-                                <div className="large-text">
-                                    {this.state.avg_star ? this.state.avg_star : 0}
-                                </div>
-                            </div>
-                            <div className="rating-bar-chart">
-                                <BarChart layout='vertical' width={400} height={250} data={this.state.skill_ratings}>
-                                    <XAxis type="number" padding={{right: 20}} />
-                                    <YAxis dataKey="name" type="category"/>
-                                    <Tooltip
-                                        wrapperStyle={{height: '60px'}}
-                                    />
-                                    <Bar name="Skill Rating" dataKey="value" fill="#8884d8">
-                                        <LabelList dataKey="value" position="right" />
-                                        {
-                                            this.state.skill_ratings
-                                                .map((entry, index) =>
-                                                    <Cell key={index} fill={
-                                                        ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#FF2323'][index % 5]
-                                                    }/>)
-                                        }
-                                    </Bar>
-                                </BarChart>
-                            </div>
-                            <div className="total-rating">
-                                Total Ratings
-                                <div className="large-text">
-                                    { this.state.skill_ratings.total_star || 0 }
-                                </div>
-                            </div>
-                        </div>
+                        {
+                            this.state.total_reviews !== 0?
+                                (<div className="ratings-section">
+                                    <div className="average">
+                                        Average Rating
+                                        <div className="large-text">
+                                            {this.state.avg_star || 0}
+                                        </div>
+                                    </div>
+                                    <div className="rating-bar-chart">
+                                        <BarChart layout='vertical' width={400} height={250} data={this.state.skill_ratings}>
+                                            <XAxis type="number" padding={{right: 20}} />
+                                            <YAxis dataKey="name" type="category"/>
+                                            <Tooltip
+                                                wrapperStyle={{height: '60px'}}
+                                            />
+                                            <Bar name="Skill Rating" dataKey="value" fill="#8884d8">
+                                                <LabelList dataKey="value" position="right" />
+                                                {
+                                                    this.state.skill_ratings
+                                                        .map((entry, index) =>
+                                                            <Cell key={index} fill={
+                                                                ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#FF2323'][index % 5]
+                                                            }/>)
+                                                }
+                                            </Bar>
+                                        </BarChart>
+                                    </div>
+                                    <div className="total-rating">
+                                        Total Ratings
+                                        <div className="large-text">
+                                            { this.state.skill_ratings.total_star || 0 }
+                                        </div>
+                                    </div>
+                                </div>):
+                                (<div className="ratings-default-message">No ratings data available yet, be the first to rate this skill!</div>)
+                        }
                     </Paper>
                 </div>
             </div>


### PR DESCRIPTION
Fixes #499 

Changes: Display a message when no ratings for the skill are present.

Surge Deployment Link: https://pr-529-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/40668705-d60ffd1a-6382-11e8-8abd-b74eeb0fabc2.png)
