### PR TITLE
Solved issue of skills not being displayed on Skill CMS

### DIFF
--- a/docs/DisplayingSkills.md
+++ b/docs/DisplayingSkills.md
@@ -7,7 +7,7 @@
 This endpoint accepts `POST` request with data supplied in the following parameters.
 
    >- model:general (default)
-   >- group:Knowledge (default)
+   >- group:All (default)
    >- language:en (default)
 
 The [Skill Browser Component](https://github.com/fossasia/susi_skill_cms/tree/master/src/components/BrowseSkill) we send request to the a forementioned endpoint to display all the skills in a category and language.

--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -164,7 +164,7 @@ export default class BrowseSkill extends React.Component {
                   // console.log(url);
         }
         else {
-            url = urls.API_URL + '/cms/getSkillList.json?applyFilter=true&filter_name=ascending&filter_type=lexicographical'
+            url = urls.API_URL + '/cms/getSkillList.json?group=Knowledge&applyFilter=true&filter_name=ascending&filter_type=lexicographical'
         }
 
         let self = this;
@@ -259,8 +259,8 @@ export default class BrowseSkill extends React.Component {
                         description = 'No description available'
                     }
                     if (skill.skill_rating) {
-                        average_rating = skill.skill_rating.avg_star;
-                        total_rating = skill.skill_rating.avg_star;
+                        average_rating = parseInt(skill.skill_rating.avg_star,10);
+                        total_rating = parseInt(skill.skill_rating.total_star,10);
                     }
 
                     cards.push(

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -70,7 +70,7 @@ class SkillListing extends Component {
 
         let clickedSkill = this.props.location.pathname.split('/')[2];
         this.name = clickedSkill;
-        this.url = urls.API_URL + '/cms/getSkillList.json';
+        this.url = urls.API_URL + '/cms/getSkillList.json?group=Knowledge';
         if (this.url !== undefined) {
             let url = this.url;
             this.name = clickedSkill;


### PR DESCRIPTION
Fixes #578 

Changes: Solved issue of skills not being displayed on Skill CMS. Now, it's displaying the Skills of group "Knowledge" by default, just like it used to do earlier.

Surge Deployment Link: https://pr-579-fossasia-susi-skill-cms.surge.sh
