### PR TITLE
change color picker in botbuilder design page

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "jquery": "latest",
     "match-media": "^0.2.0",
     "material-ui": "^0.18.3",
+    "material-ui-color-picker": "^2.0.1",
     "material-ui-password-field": "^1.2.0",
     "material-ui-search-bar": "^0.4.2",
     "prop-types": "latest",

--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -60,6 +60,19 @@
 .copy-button:hover{
 	background-color: #729ce2;
 }
+.color-box{
+	width: 23px;
+	height: 23px;
+	display: inline-block;
+	border-radius: 3px;
+	border: solid 1px #0000006e;
+}
+.color-picker-wrap>div{
+	display: inline-block;
+}
+.color-picker-wrap>div>div{
+	width:200px;
+}
 @media (min-width:769px){
 	.botbuilder-page-wrapper{
 		padding: 40px 30px 30px;

--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -5,9 +5,9 @@ import * as $ from 'jquery';
 import Cookies from 'universal-cookie';
 import Snackbar from 'material-ui/Snackbar';
 import CircularProgress from 'material-ui/CircularProgress';
+import ColorPicker from 'material-ui-color-picker'
 import colors from '../../../Utils/colors';
 import urls from '../../../Utils/urls';
-import { SketchPicker } from 'react-color';
 const cookies = new Cookies();
 let BASE_URL = urls.API_URL;
 class Design extends React.Component {
@@ -15,23 +15,24 @@ class Design extends React.Component {
     constructor(props){
         super(props);
         this.state = {
-            botbuilderBackgroundBody:'',
+            botbuilderBackgroundBody:'#ffffff',
             botbuilderBodyBackgroundImg:'',
-            botbuilderUserMessageBackground:'',
-            botbuilderUserMessageTextColor:'',
-            botbuilderBotMessageBackground:'',
-            botbuilderBotMessageTextColor:'',
-            botbuilderIconColor:'',
+            botbuilderUserMessageBackground:'#0077e5',
+            botbuilderUserMessageTextColor:'#ffffff',
+            botbuilderBotMessageBackground:'#f8f8f8',
+            botbuilderBotMessageTextColor:'#455a64',
+            botbuilderIconColor:'#000000',
             botbuilderIconImg:'',
             saving:false,
             openSnackbar:false,
             msgSnackbar:'',
+            loadedSettings:false
         }
         this.getSettings();
     }
 
-    handleChangeComplete = (component,color) =>{
-        this.setState({[component]:color.hex});
+    handleChangeColor = (component,color) =>{
+        this.setState({[component]:color});
     }
 
     handleChangeBodyBackgroundImage = (botbuilderBodyBackgroundImg) =>{
@@ -111,6 +112,13 @@ class Design extends React.Component {
                     openSnackbar:true,
                     msgSnackbar:'Success! Saved settings'
                 });
+            }.bind(this),
+            error: function (textStatus, errorThrown) {
+                this.setState({
+                    saving:false,
+                    openSnackbar:true,
+                    msgSnackbar:'Error! Can\'t save your settings. Try logging again'
+                });
             }.bind(this)
         });
     }
@@ -128,6 +136,7 @@ class Design extends React.Component {
                 if(data.settings){
                     let settings = data.settings;
                     this.setState({
+                        loadedSettings:true,
                         botbuilderBackgroundBody:'#'+settings.botbuilderBackgroundBody,
                         botbuilderBodyBackgroundImg:settings.botbuilderBodyBackgroundImg,
                         botbuilderUserMessageBackground:'#'+settings.botbuilderUserMessageBackground,
@@ -155,13 +164,16 @@ class Design extends React.Component {
         const customizeComponents = customiseOptionsList.map((component) => {
             return <div key={component.id} className='circleChoose'>
                 <h2>Color of {component.name}</h2>
-                <div className='center'>
-                    <SketchPicker
-                        className='center'
-                        color={ this.state[component.component] }
-                        onChangeComplete={(color)=>
-                            this.handleChangeComplete(component.component,color) }
+            <div className='color-picker-wrap'>
+                        <ColorPicker
+                            className='color-picker'
+                            style={{display:'inline-block',float:'left'}}
+                            name='color'
+                            defaultValue={ this.state[component.component] }
+                            onChange={(color)=>
+                                this.handleChangeColor(component.component,color) }
                         />
+                    <span className='color-box' style={{backgroundColor:this.state[component.component]}}></span>
                     </div>
                     {component.component === 'botbuilderBackgroundBody' && <div>
                         <TextField
@@ -205,7 +217,7 @@ class Design extends React.Component {
                 return(
                     <div className="center menu-page">
                         <div className='design-box'>
-                            {customizeComponents}
+                            {this.state.loadedSettings && customizeComponents}
                             <div className='center'>
                                 <RaisedButton
                                     name='save'


### PR DESCRIPTION
Fixes #565 

Changes: 
- change the color picker component in botbuilder design page to `material-ui-color-picker`.

Surge Deployment Link: https://pr-580-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17807257/40977215-f0808046-68ed-11e8-96bf-533bf3761fa3.png)

