### PR TITLE
Fixes #593: Parse the avg_star as Float

### DIFF
--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -177,7 +177,7 @@ class SkillListing extends Component {
         console.log(skill_ratings);
         this.setState({
             skill_ratings: ratings_data,
-            avg_rating: parseInt(skill_ratings.avg_star, 10),
+            avg_rating: parseFloat(skill_ratings.avg_star),
             total_star: parseInt(skill_ratings.total_star, 10)
         })
     }


### PR DESCRIPTION
Fixes #593 

Changes: Parse the avg_rating as float.

Surge Deployment Link: https://pr-598-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/41023553-5eebaa1e-698a-11e8-8b66-6daf11ebf2b3.png)
