### PR TITLE
Hide email on mobile view to avoid overlapping with susi logo

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.css
+++ b/src/components/StaticAppBar/StaticAppBar.css
@@ -48,3 +48,8 @@ header {
         margin: 0 auto;
     }
 }
+@media only screen and (max-width: 516px){
+    .useremail{
+        display: none;
+    }
+}

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -213,7 +213,7 @@ class StaticAppBar extends Component {
             <div onScroll={this.handleScroll}>
                 <div>
                     {cookies.get('loggedIn') ?
-                        (<label
+                        (<label className="useremail"
                             style={{color: 'white', fontSize: '16px', verticalAlign:'super'}}>
                             {cookies.get('emailId')}
                             </label>) :


### PR DESCRIPTION
Fixes #583 

Changes: Hide email in mobile view on top bar to avoid overlapping with susi logo

Surge Deployment Link: https://pr-608-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![b1](https://user-images.githubusercontent.com/30981465/41056596-551b7b6a-69e2-11e8-84af-5cfff53844e5.png)
