### PR TITLE
Added average skill rating on home page

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -261,8 +261,8 @@ export default class BrowseSkill extends React.Component {
                         description = 'No description available'
                     }
                     if (skill.skill_rating) {
-                        average_rating = parseInt(skill.skill_rating.avg_star,10);
-                        total_rating = parseInt(skill.skill_rating.total_star,10);
+                        average_rating = parseInt(skill.skill_rating.stars.avg_star,10);
+                        total_rating = parseInt(skill.skill_rating.stars.total_star,10);
                     }
 
                     cards.push(

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -274,28 +274,31 @@ class SkillListing extends Component {
     };
 
     parseDate = dtstr => {
-        // replace anything but numbers by spaces
-        dtstr = dtstr.replace(/\D/g,' ');
-        // trim any hanging white space
-        dtstr = dtstr.replace(/\s+$/,'');
-        // split on space
-        var dtcomps = dtstr.split(' ');
-        // not all ISO 8601 dates can convert, as is
-        // unless month and date specified, invalid
-        if (dtcomps.length < 3) {
-            return 'Invalid date';
+        if (dtstr) {
+            // replace anything but numbers by spaces
+            dtstr = dtstr.replace(/\D/g,' ');
+            // trim any hanging white space
+            dtstr = dtstr.replace(/\s+$/,'');
+            // split on space
+            var dtcomps = dtstr.split(' ');
+            // not all ISO 8601 dates can convert, as is
+            // unless month and date specified, invalid
+            if (dtcomps.length < 3) {
+                return 'Invalid date';
+            }
+            // if time not provided, set to zero
+            if (dtcomps.length < 4) {
+                dtcomps[3] = 0;
+                dtcomps[4] = 0;
+                dtcomps[5] = 0;
+            }
+            // modify month between 1 based ISO 8601 and zero based Date
+            dtcomps[1]--;
+            const convdt = new
+            Date(Date.UTC(dtcomps[0],dtcomps[1],dtcomps[2],
+                dtcomps[3],dtcomps[4],dtcomps[5]));
+            return convdt.toUTCString();
         }
-        // if time not provided, set to zero
-        if (dtcomps.length < 4) {
-            dtcomps[3] = 0;
-            dtcomps[4] = 0;
-            dtcomps[5] = 0;
-        }
-        // modify month between 1 based ISO 8601 and zero based Date
-        dtcomps[1]--;
-        const convdt = new
-        Date(Date.UTC(dtcomps[0],dtcomps[1],dtcomps[2],dtcomps[3],dtcomps[4],dtcomps[5]));
-        return convdt.toUTCString();
     }
 
     render() {


### PR DESCRIPTION
Fixes 
Show overall skill rating on CMS homepage. #607

Changes: 
Parsed the rating object correctly to display the average rating and total number of ratings on a skill.

Surge Deployment Link: http://susi--cms.surge.sh/

Screenshots for the change:
![image](https://user-images.githubusercontent.com/10573038/41082682-c59fa89c-6a4c-11e8-9820-5afb720061d9.png)

