### PR TITLE
Implemented country wise skill usage analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "prop-types": "latest",
     "react": "^15.6.1",
     "react-ace": "^5.1.0",
+    "react-chartkick": "^0.2.0",
     "react-codemirror": "^1.0.0",
     "react-color": "^2.14.1",
     "react-copy-to-clipboard": "^5.0.1",

--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="main.css"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/antd/2.11.1/antd.min.css">
     <link rel="stylesheet" href="codemirror.css">
+    <script src="https://www.gstatic.com/charts/loader.js"></script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.js
+++ b/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.js
@@ -1,0 +1,26 @@
+// Packages
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Paper } from 'material-ui';
+import { GeoChart } from 'react-chartkick'
+
+class CountryWiseSkillUsageCard extends Component {
+	render() {
+		return(
+			<Paper className="margin-b-md margin-t-md">
+				<h1 className='title'>
+					Country Wise Skill Usage
+				</h1>
+				<div className="skill-usage-graph">
+					<GeoChart data={this.props.country_wise_skill_usage} />
+				</div>
+			</Paper>
+		)
+	}
+}
+
+CountryWiseSkillUsageCard.propTypes = {
+	country_wise_skill_usage: PropTypes.array
+}
+
+export default CountryWiseSkillUsageCard;

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -10,6 +10,7 @@ import AuthorSkills from '../AuthorSkills/AuthorSkills'
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import SkillUsageCard from '../SkillUsageCard/SkillUsageCard';
 import SkillRatingCard from '../SkillRatingCard/SkillRatingCard';
+import CountryWiseSkillUsageCard from '../CountryWiseSkillUsageCard/CountryWiseSkillUsageCard';
 import {
     FloatingActionButton,
     Paper,
@@ -72,6 +73,7 @@ class SkillListing extends Component {
             total_star: '',
             skill_ratings: [],
             skill_usage: [],
+            country_wise_skill_usage: [],
             rating : 0,
         };
 
@@ -102,6 +104,8 @@ class SkillListing extends Component {
             let baseUrl = urls.API_URL + '/cms/getSkillMetadata.json';
             let skillRatingUrl = `${urls.API_URL}/cms/getSkillRating.json`;
             let skillUsageUrl = `${urls.API_URL}/cms/getSkillUsage.json`;
+            let countryWiseSkillUsageUrl =
+            	`${urls.API_URL}/cms/getCountryWiseSkillUsage.json`;
             let url = this.url;
 
             let modelValue = 'general';
@@ -110,6 +114,7 @@ class SkillListing extends Component {
             url = baseUrl + '?model=' + modelValue + '&group=' + this.groupValue + '&language=' + this.languageValue + '&skill=' + this.name;
             skillRatingUrl = skillRatingUrl + '?model=' + modelValue + '&group=' + this.groupValue + '&language=' + this.languageValue + '&skill=' + this.name;
             skillUsageUrl = skillUsageUrl + '?model=' + modelValue + '&group=' + this.groupValue + '&language=' + this.languageValue + '&skill=' + this.name;
+            countryWiseSkillUsageUrl = countryWiseSkillUsageUrl + '?model=' + modelValue + '&group=' + this.groupValue + '&language=' + this.languageValue + '&skill=' + this.name;
             // console.log('Url:' + url);
             let self = this;
             $.ajax({
@@ -146,6 +151,18 @@ class SkillListing extends Component {
                 },
                 error: function(e) {
                     self.saveSkillUsage()
+                }
+            });
+            // Fetch country wise skill usage of the visited skill
+            $.ajax({
+                url: countryWiseSkillUsageUrl,
+                dataType: 'json',
+                crossDomain: true,
+                success: function (data) {
+                    self.saveCountryWiseSkillUsage(data.skill_usage)
+                },
+                error: function(e) {
+                    self.saveCountryWiseSkillUsage()
                 }
             });
         }
@@ -215,6 +232,16 @@ class SkillListing extends Component {
         ];
         this.setState({
             skill_usage: data
+        })
+    }
+
+    saveCountryWiseSkillUsage = (country_wise_skill_usage = []) => {
+        // Add sample data to test
+        let data=country_wise_skill_usage
+        .map(country => [country.country_code, Number(country.count)]);
+
+        this.setState({
+            country_wise_skill_usage: data
         })
     }
 
@@ -494,6 +521,8 @@ class SkillListing extends Component {
                     />
 
                    <SkillUsageCard skill_usage={this.state.skill_usage} />
+                   <CountryWiseSkillUsageCard
+						country_wise_skill_usage={this.state.country_wise_skill_usage} />
                 </div>
             </div>
         }


### PR DESCRIPTION
Fixes 
Display country wise skill usage #622 

Changes: 
1. Added react-chartkick components for GeoCharts.
2. Fetched country wise skill usage from the API and show it on the skill analytics.

Needs the following PRs to be merged :
fossasia/chat.susi.ai#1309
fossasia/susi_server#811

Surge Deployment Link: https://susi-ai-chat.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/10573038/41170981-6d3a113a-6b6c-11e8-990d-857eeeeeb7c7.png)
