### PR TITLE
Added title text to remove ambiguity in the number besides the Rating widget on skill cards

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -310,7 +310,7 @@ export default class BrowseSkill extends React.Component {
                                         <Ratings.Widget />
                                         <Ratings.Widget />
                                     </Ratings>
-                                    <span style={styles.totalRating}>
+                                    <span style={styles.totalRating} title="Total ratings">
                                         {total_rating || 0}
                                     </span>
                                 </div>

--- a/src/components/BrowseSkill/SkillStyle.js
+++ b/src/components/BrowseSkill/SkillStyle.js
@@ -1,5 +1,4 @@
 const styles = {
-
     center: {
         display: 'flex',
         alignItems: 'center',
@@ -118,7 +117,7 @@ const styles = {
         float: 'left',
     },
     totalRating : {
-        fontSize : '12px',
+        fontSize : '13px',
         paddingLeft : '5px',
         color : '#108ee9'
     }


### PR DESCRIPTION
Fixes #626 

**Changes:** Added appropriate text to remove ambiguity in the number besides the Rating widget on skill cards

**Surge Deployment Link:** https://pr-634-fossasia-susi-skill-cms.surge.sh

**Screenshots for the change:**

**Before:**
![totalratingold](https://user-images.githubusercontent.com/31135861/41187834-896a56b2-6bd0-11e8-8593-af4f7a7c827b.png)


**After:**
![titletext](https://user-images.githubusercontent.com/31135861/41188816-2df55974-6be1-11e8-8c5d-1bb07374d961.png)

