### PR TITLE
Shortened the skill description to prevent overlap with Ratings widget on skill card

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -250,8 +250,8 @@ export default class BrowseSkill extends React.Component {
                         examples = null
                     }
                     if (skill.descriptions) {
-                        if (skill.descriptions.length > 120) {
-                            description = skill.descriptions.substring(0, 119) + '...';
+                        if (skill.descriptions.length > 105) {
+                            description = skill.descriptions.substring(0, 104) + '...';
                         }
                         else {
                             description = skill.descriptions;


### PR DESCRIPTION
Fixes #627 

**Changes:** Shortened the skill description to prevent overlap with Ratings widget on skill card

**Surge Deployment Link:** https://pr-635-fossasia-susi-skill-cms.surge.sh

**Screenshots for the change:**

**Before:**
![shortenskilldescription](https://user-images.githubusercontent.com/31135861/41187887-86c34a94-6bd1-11e8-80ec-a1002f04aad2.png)

**After:**
![shortenskilldescriptionnew](https://user-images.githubusercontent.com/31135861/41187893-a6041eec-6bd1-11e8-99c8-dbfb4a303f67.png)
