### PR TITLE
create dashboard page

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -5,7 +5,7 @@ import SelectField from 'material-ui/SelectField';
 import { Paper } from 'material-ui';
 import { Card } from 'material-ui/Card';
 import * as $ from 'jquery';
-import { Link } from 'react-router-dom'
+import { Link } from 'react-router-dom';
 import IconMenu from 'material-ui/IconMenu';
 import MenuItem from 'material-ui/MenuItem';
 import IconButton from 'material-ui/IconButton';
@@ -434,8 +434,6 @@ export default class BrowseSkill extends React.Component {
                                 <IconMenu
                                     anchorOrigin={{vertical:'bottom',horizontal:'middle'}}
                                     iconButtonElement={<IconButton className='add-button' iconStyle={{color:'#fff'}} style={addButtonStyle}><Add /></IconButton>}
-                                    open={this.state.openMenu}
-                                    onRequestChange={this.handleOnRequestChange}
                                     >
                                         <Link to='/skillCreator'><MenuItem leftIcon={<Add />} primaryText="Create a Skill" /></Link>
                                         <Link to='/botbuilder'><MenuItem leftIcon={<Person />} primaryText="Create Skill bot" /></Link>

--- a/src/components/Dashboard/Dashboard.css
+++ b/src/components/Dashboard/Dashboard.css
@@ -1,0 +1,9 @@
+
+.table-wrap >div{
+    min-width: 700px;
+}
+@media (max-width:769px){
+    .table-wrap{
+        overflow-x: scroll;
+    }
+}

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
+import { Paper } from 'material-ui';
+import Cookies from 'universal-cookie';
+import MySkills from './MySkills';
+import './Dashboard.css';
+const cookies = new Cookies();
+
+class Dashboard extends React.Component {
+
+    constructor(props){
+        super(props);
+        this.state = {
+            activeTab: 0,
+            showPreview:false,
+            chatbotOpen: false,
+            createBotWizard: true
+        }
+    }
+
+    render() {
+        if(!cookies.get('loggedIn'))
+        {
+            return (
+                <div>
+                    <StaticAppBar {...this.props} />
+                    <div>
+                        <p style={styles.loggedInError}>
+                            Please login to view dashboard.
+                        </p>
+                    </div>
+                </div>
+            );
+        }
+        return (
+            <div>
+                <StaticAppBar {...this.props} />
+                <div style={styles.home} className="botbuilder-page-wrapper">
+                    <Paper style={styles.paperStyle} className="botBuilder-page-card" zDepth={1}>
+                        <h1 className='center'>My Dashboard</h1>
+                        <MySkills/>
+                    </Paper>
+                </div>
+              </div>
+        )
+    }
+}
+
+const styles = {
+    home: {
+        width: '100%'
+    },
+    bg: {
+        textAlign: 'center',
+        padding: '30px',
+    },
+    paperStyle: {
+        width: '100%',
+        marginTop:'20px',
+    },
+    tabStyle: {
+        color:'rgb(91, 91, 91)'
+    },
+    previewButtonStyle: {
+        width: '100px',
+        marginTop:'50px'
+    },
+    loggedInError: {
+        textAlign:'center',
+        textTransform:'uppercase',
+        fontWeight:'bold',
+        marginBottom: '100px',
+        fontSize: '50px',
+        marginTop: '300px'
+    }
+};
+
+Dashboard.propTypes = {
+};
+
+export default Dashboard;

--- a/src/components/Dashboard/MySkills.js
+++ b/src/components/Dashboard/MySkills.js
@@ -1,0 +1,233 @@
+import React, {Component} from 'react';
+import {
+    Table,
+    TableBody,
+    TableHeader,
+    TableHeaderColumn,
+    TableRow,
+    TableRowColumn,
+} from 'material-ui/Table';
+import Cookies from 'universal-cookie';
+import SelectField from 'material-ui/SelectField';
+import Link from 'react-router-dom/es/Link';
+import Person from 'material-ui/svg-icons/social/person';
+import IconMenu from 'material-ui/IconMenu';
+import IconButton from 'material-ui/IconButton';
+import RaisedButton from 'material-ui/RaisedButton';
+import CircularProgress from 'material-ui/CircularProgress';
+import Snackbar from 'material-ui/Snackbar';
+import Toggle from 'material-ui/Toggle';
+import MenuItem from 'material-ui/MenuItem';
+import * as $ from 'jquery';
+import Add from 'material-ui/svg-icons/content/add';
+import urls from '../../Utils/urls';
+import colors from '../../Utils/colors';
+const cookies = new Cookies();
+
+class MySkills extends Component {
+
+    constructor(props){
+        super(props);
+        this.state={
+            skillsData:[],
+            loading: true,
+            openSnackbar: false,
+            showMySkills: false,
+            msgSnackbar:'',
+            openMenu:false,
+            openMenuBottom:false
+        }
+    }
+    componentDidMount(){
+        this.loadSkills();
+    }
+    handleShowSkills = () =>{
+
+    }
+    loadSkills = () => {
+        let url;
+        url = urls.API_URL + '/cms/getSkillList.json?applyFilter=true&filter_name=ascending&filter_type=lexicographical';
+        let self = this;
+        let skillsData = [];
+        $.ajax({
+            url: url,
+            jsonpCallback: 'pxcd',
+            dataType: 'jsonp',
+            jsonp: 'callback',
+            crossDomain: true,
+            success: function (data) {
+              for(let i of data.filteredData){
+                  skillsData.push({
+                      skill_name:i.skill_name,
+                      type:'public',
+                      status:'active',
+                      ...i
+                  })
+              }
+              self.setState({
+                  skillsData,
+                  loading:false
+              });
+            },
+            error: function (err){
+              self.setState({
+                  loading: false,
+                  openSnackbar:false,
+                  msgSnackbar:'Error. Couldn\'t fetch skills.'
+              })
+            }
+        });
+    }
+
+    handleShowMySkills = (event, isInputChecked) =>{
+        this.setState({showMySkills:isInputChecked});
+    }
+    handleOnRequestChangeBottom = (value) =>{
+        this.setState({
+            openMenuBottom: value,
+        });
+    }
+    handleOnRequestChange = (value) =>{
+        this.setState({
+            openMenu: value,
+        });
+    }
+    render() {
+        let skillsData = this.state.skillsData.filter((item)=>{
+            if(!this.state.showMySkills || item.author_email === cookies.get('loggedIn')){
+                return item;
+            }
+            return null;
+        });
+        return (
+            <div>
+                <div style={{textAlign:'right'}}>
+                    <IconMenu
+                        anchorOrigin={{vertical:'bottom',horizontal:'middle'}}
+                        label='Add new skill'
+                        open={this.state.openMenu}
+                        onRequestChange={this.handleOnRequestChange}
+                        iconButtonElement={<IconButton className='add-button' iconStyle={{color:'#fff'}}><Add /></IconButton>}
+                        >
+                            <Link to='/skillCreator'><MenuItem leftIcon={<Add />} primaryText="Create a Skill" /></Link>
+                        <Link to='/botbuilder'><MenuItem leftIcon={<Person />} primaryText="Create Skill bot" /></Link>
+                    </IconMenu>
+                    <RaisedButton
+                        backgroundColor={colors.header}
+                        onClick={()=>{this.setState({openMenu:true})}}
+                        label='Create Skill'
+                        labelStyle={{verticalAlign:'middle'}}
+                        labelColor='#fff'
+                        icon={<Add/>}
+                    />
+                </div>
+                {!this.state.loading &&
+                <span>
+                <Toggle
+                    style={styles.toggle}
+                    labelStyle={styles.toggleLabelStyle}
+                    label='Show my skills only'
+                    labelPosition='right'
+                    onToggle={this.handleShowMySkills}
+                    disabled={this.state.loading}
+                />
+                </span>}
+
+
+            {this.state.loading?
+                <div className='center'>
+                    <CircularProgress size={62} color='#4285f5'/>
+                <h4>Loading</h4>
+                </div>
+                :
+                <div className='table-wrap'>
+                <Table className='table-root' selectable={false}>
+                    <TableHeader
+                    displaySelectAll={false}
+                    adjustForCheckbox={false}>
+                        <TableRow>
+                            <TableHeaderColumn>Skill Name</TableHeaderColumn>
+                            <TableHeaderColumn>Type</TableHeaderColumn>
+                        <TableHeaderColumn>Author</TableHeaderColumn>
+                            <TableHeaderColumn>Status</TableHeaderColumn>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody displayRowCheckbox={false}>
+                    {skillsData.map((skill,index)=>{
+                        return (
+                            <TableRow key={index}>
+                                <TableRowColumn style={{fontSize:'16px'}}>{skill.skill_name?skill.skill_name:'NA'}</TableRowColumn>
+                                <TableRowColumn style={{fontSize:'16px'}}>{skill.type}</TableRowColumn>
+                            <TableRowColumn style={{fontSize:'16px'}}>{skill.author?skill.author:'NA'}</TableRowColumn>
+                                <TableRowColumn>
+                                    <SelectField
+                                        floatingLabelText="Status"
+                                        fullWidth={true}
+                                        value={1}
+                                        >
+                                            <MenuItem value={1} primaryText="Enable" />
+                                    </SelectField>
+                                </TableRowColumn>
+                            </TableRow>
+                        )
+                    })}
+                    <TableRow>
+
+                    </TableRow>
+                    </TableBody>
+
+                </Table>
+            </div>}
+            {skillsData.length === 0 && !this.state.loading && <div>
+                <div className='center'>
+                    <br/>
+                    <h2>Create your first skill or learn more about <a href='https://github.com/fossasia/susi_skill_cms/blob/master/docs/Skill_Tutorial.md' rel="noopener noreferrer" target='_blank'>SUSI Skills</a></h2>
+                <br/>
+                <IconMenu
+                        anchorOrigin={{vertical:'bottom',horizontal:'middle'}}
+                        label='Add new skill'
+                        open={this.state.openMenuBottom}
+                        onRequestChange={this.handleOnRequestChangeBottom}
+                        iconButtonElement={<IconButton style={{display:'none'}} iconStyle={{color:'#fff'}}><Add /></IconButton>}
+                        >
+                            <Link to='/skillCreator'><MenuItem leftIcon={<Add />} primaryText="Create a Skill" /></Link>
+                            <Link to='/botbuilder'><MenuItem leftIcon={<Person />} primaryText="Create Skill bot" /></Link>
+                        </IconMenu>
+                        <RaisedButton
+                                backgroundColor={colors.header}
+                                onClick={()=>{this.setState({openMenuBottom:true})}}
+                                label='Create Skill'
+                                labelStyle={{verticalAlign:'middle'}}
+                                labelColor='#fff'
+                                icon={<Add/>}
+                            />
+                </div>
+            </div>}
+
+            <Snackbar
+                open={this.state.openSnackbar}
+                message={this.state.msgSnackbar}
+                autoHideDuration={2000}
+                onRequestClose={()=>{this.setState({openSnackbar:false})}}
+            />
+            </div>
+        );
+    }
+}
+const styles = {
+    toggle: {
+        maxWidth: '180px'
+    },
+    toggleLabelStyle: {
+        fontSize: '15px'
+    },
+    addButtonStyle: {
+        backgroundColor: colors.fabButton,
+        borderRadius:'50%',
+        height: '56px',
+        width: '56px',
+        boxShadow: '0px 3px 13px 1px rgba(0, 0, 0, 0.23)'
+    }
+}
+
+export default MySkills;

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -253,8 +253,8 @@ class StaticAppBar extends Component {
 
                         }
                         {cookies.get('loggedIn') ?
-                            (<MenuItem primaryText='Botbuilder'
-                                containerElement={<Link to='/botbuilder' />}
+                            (<MenuItem primaryText='Dashboard'
+                                containerElement={<Link to='/dashboard' />}
                                 rightIcon={<Extension />} />) :
                             null
                         }

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import NotFound from './components/NotFound/NotFound';
 import Admin from './components/Admin/Admin'
 import BotBuilder from './components/BotBuilder/BotBuilder';
+import Dashboard from './components/Dashboard/Dashboard';
 import BrowseSkill from './components/BrowseSkill/BrowseSkill';
 import SkillListing from './components/SkillPage/SkillListing';
 import ListUser from './components/Admin/ListUser/ListUser';
@@ -47,6 +48,7 @@ class App extends React.Component {
                         <Route exact path='/botbuilder/contactbot' component={ContactBot} />
                         <Route exact path='/botbuilder/botwizard' component={BotWizard} />
                         <Route exact path='/botbuilder' component={BotBuilder}/>
+                        <Route exact path='/dashboard' component={Dashboard}/>
                         <Route exact path='/logout' component={Logout} />
                         <Route exact path='/skillCreator' component={CreateSkill}/>
                         <Route exact path='/:category/:skill/versions/:lang' component={SkillVersion}/>


### PR DESCRIPTION
Fixes #587 

Changes: 
- Change the menu option `botbuilder` to `dashboard`. 
- Create the dashboard page showing all the skills in a table. 
  - A "toggle" option is given to show only "my skills" (i.e skills created by the user).
  - Add "Create Skill" button.
  - Show the message "Create your first skill.." when no skills are present. 
  - Add loading animation while the skills are loading.

Surge Deployment Link: https://pr-644-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
Menu popup:
![dashboardmenu](https://user-images.githubusercontent.com/17807257/41196733-d29cee9a-6c65-11e8-9fc5-1a1d644f75b5.png)
While loading:
![dashboard0](https://user-images.githubusercontent.com/17807257/41196755-319c9562-6c66-11e8-97e9-4c89acaba4c1.png)
After loading, showing all skills:
![dashboard1](https://user-images.githubusercontent.com/17807257/41196736-ec24269e-6c65-11e8-9005-addc7bea20c4.png)
When no "My skill" is present:
![dashboard2](https://user-images.githubusercontent.com/17807257/41196740-fc9e8500-6c65-11e8-9a85-baee83035f05.png)

