### PR TITLE
Fixes #657: Display a message when no skill usage data is present

### DIFF
--- a/src/components/SkillPage/SkillListing.css
+++ b/src/components/SkillPage/SkillListing.css
@@ -141,12 +141,6 @@ abbr[title] {
   font-size: 48px;
 }
 
-.ratings-default-message {
-  margin: 10px;
-  display: flex;
-  justify-content: center;
-  padding-bottom: 10px;
-}
 
 .card-content {
   padding-left: 20px;

--- a/src/components/SkillRatingCard/SkillRatingCard.css
+++ b/src/components/SkillRatingCard/SkillRatingCard.css
@@ -31,6 +31,18 @@
 }
 
 .rating-message {
-    text-align: center;
-    font-size: 16px;
+  text-align: center;
+  font-size: 16px;
+}
+
+.ratings-default-message {
+  margin: 10px;
+  display: flex;
+  justify-content: center;
+  padding-bottom: 10px;
+}
+
+.rating-message {
+  text-align: center;
+  font-size: 16px;
 }

--- a/src/components/SkillUsageCard/SkillUsage.css
+++ b/src/components/SkillUsageCard/SkillUsage.css
@@ -1,0 +1,6 @@
+.default-message {
+  margin: 10px;
+  display: flex;
+  justify-content: center;
+  padding-bottom: 10px;
+}

--- a/src/components/SkillUsageCard/SkillUsageCard.js
+++ b/src/components/SkillUsageCard/SkillUsageCard.js
@@ -4,23 +4,35 @@ import PropTypes from 'prop-types';
 import { LineChart, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts';
 import { Paper } from 'material-ui';
 
+// Static assets
+import './SkillUsage.css';
+
 class SkillUsageCard extends Component {
 	render() {
+
+		const totalSkillUsage = this.props.skill_usage.reduce((totalCount, day) => {
+			return totalCount + day.count
+		}, 0)
+		console.log(totalSkillUsage);
 		return(
 			<Paper className="margin-b-md margin-t-md">
 				<h1 className='title'>
 					Skill Usage
 				</h1>
-				<div className="skill-usage-graph">
-					<LineChart width={600} height={300} data={this.props.skill_usage}
-							margin={{top: 5, right: 30, left: 20, bottom: 5}}>
-						<XAxis dataKey="date" padding={{right: 20}} />
-						<YAxis/>
-						<Tooltip wrapperStyle={{height: '60px'}}/>
-						<Legend />
-						<Line name='Skill usage count' type="monotone" dataKey="count" stroke="#82ca9d" activeDot={{r: 8}}/>
-					</LineChart>
-				</div>
+				{
+					totalSkillUsage > 0 ?
+					(<div className="skill-usage-graph">
+						<LineChart width={600} height={300} data={this.props.skill_usage}
+								margin={{top: 5, right: 30, left: 20, bottom: 5}}>
+							<XAxis dataKey="date" padding={{right: 20}} />
+							<YAxis/>
+							<Tooltip wrapperStyle={{height: '60px'}}/>
+							<Legend />
+							<Line name='Skill usage count' type="monotone" dataKey="count" stroke="#82ca9d" activeDot={{r: 8}}/>
+						</LineChart>
+					</div>):
+					(<div className="default-message">No usage data available, try this skill now!</div>)
+				}
 			</Paper>
 		)
 	}


### PR DESCRIPTION
Fixes #657 

Changes: Calculate total skill hits and display a message when skill is unused.

Surge Deployment Link: https://pr-661-fossasia-susi-skill-cms.surge.sh

Please suggest if the default message can be improved. 

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/41214083-e4e98aa2-6d66-11e8-90bc-f0be4c94621d.png)
