### PR TITLE
Fixes #638: Rectify the card sizing issue in skill example cards

### DIFF
--- a/src/components/SkillPage/SkillListing.css
+++ b/src/components/SkillPage/SkillListing.css
@@ -34,23 +34,21 @@ abbr[title] {
   transform: scale(1.2);
 }
 
-.examples{
+.examples {
   display: flex;
   flex-wrap: wrap;
 }
 
-.examples > div{
+.examples > div {
     margin-top:10px ;
 }
 
-.exampleTile{
-  height: auto;
+.exampleTile {
   width: 200px;
   margin-right: 20px;
   box-shadow: none;
   padding: 20px;
   color: #555;
-  max-height: 80px;
 }
 
 .margin-b-md {
@@ -88,7 +86,7 @@ abbr[title] {
   float: left;
 }
 
-.skillEditBtn > button{
+.skillEditBtn > button {
     background-color: #4285f4;
 }
 
@@ -107,7 +105,7 @@ abbr[title] {
   flex-direction: column;
 }
 
-@media only screen and (min-width: 0px) and (max-width: 768px){
+@media only screen and (min-width: 0px) and (max-width: 768px) {
 
   .avatar-img {
      display:inline;
@@ -117,7 +115,7 @@ abbr[title] {
         text-align:center;
     }
 
-  .exampleTile{
+  .exampleTile {
     width: 90%;
   }
   .skill_listing_container {

--- a/src/components/SkillPage/SkillListing.css
+++ b/src/components/SkillPage/SkillListing.css
@@ -35,6 +35,7 @@ abbr[title] {
 }
 
 .examples {
+  height: max-content;
   display: flex;
   flex-wrap: wrap;
 }

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -149,7 +149,7 @@ class SkillListing extends Component {
                 }
             });
         }
-        if(this.props.location.state!==undefined){
+        if(this.props.location.state !== undefined){
             if (this.props.location.state.from_upload !== undefined) {
                 let baseUrl = urls.API_URL + '/cms/getSkillMetadata.json';
                 let url;


### PR DESCRIPTION
Fixes #638 

Changes: Solve the example card height issue in example skill cards.

Surge Deployment Link: https://pr-662-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
Now:
![image](https://user-images.githubusercontent.com/21009455/41215158-9e1f691a-6d6c-11e8-827d-867f27dfc721.png)

Before:
![image](https://user-images.githubusercontent.com/21009455/41215174-ad6636d8-6d6c-11e8-900b-2418ff0704d2.png)
