### PR TITLE
Encode some special characters in AJAX request

### DIFF
--- a/public/susi-chatbot.js
+++ b/public/susi-chatbot.js
@@ -270,7 +270,7 @@ function enableBot(){
 			setLoadingMessage(thisMsgNumber);
 			$.ajax({
 				type: "GET",
-				url: baseUrl+text,
+				url: baseUrl+encodeURIComponent(text),
 				contentType: "application/json",
 				dataType: "json",
 				success: function(data) {


### PR DESCRIPTION
Fixes #653 

Changes: Encoded special characters like +, &, = etc in AJAX request.

Screenshots for the change:
<img width="340" alt="screen shot 2018-06-11 at 2 06 30 pm" src="https://user-images.githubusercontent.com/31174685/41221204-18d320e8-6d81-11e8-8bf4-3843e2f36233.png">
<img width="423" alt="screen shot 2018-06-11 at 2 06 44 pm" src="https://user-images.githubusercontent.com/31174685/41221211-1a344d4a-6d81-11e8-8633-e488278084bf.png">
<img width="421" alt="screen shot 2018-06-11 at 2 06 50 pm" src="https://user-images.githubusercontent.com/31174685/41221213-1b52a30c-6d81-11e8-95f6-35867b02b47b.png">
<img width="431" alt="screen shot 2018-06-11 at 2 06 57 pm" src="https://user-images.githubusercontent.com/31174685/41221215-1c5918b2-6d81-11e8-820b-23ec5e0469a9.png">

