### PR TITLE
Fixes #674: Replace loading text with animation

### DIFF
--- a/src/components/Dashboard/MySkills.js
+++ b/src/components/Dashboard/MySkills.js
@@ -123,14 +123,14 @@ class MySkills extends Component {
                 </div>
                 {!this.state.loading &&
                 <span>
-                <Toggle
-                    style={styles.toggle}
-                    labelStyle={styles.toggleLabelStyle}
-                    label='Show my skills only'
-                    labelPosition='right'
-                    onToggle={this.handleShowMySkills}
-                    disabled={this.state.loading}
-                />
+                    <Toggle
+                        style={styles.toggle}
+                        labelStyle={styles.toggleLabelStyle}
+                        label='Show my skills only'
+                        labelPosition='right'
+                        onToggle={this.handleShowMySkills}
+                        disabled={this.state.loading}
+                    />
                 </span>}
 
 

--- a/src/components/SkillHistory/SkillHistory.js
+++ b/src/components/SkillHistory/SkillHistory.js
@@ -4,6 +4,15 @@ import {Link} from 'react-router-dom';
 import notification from 'antd/lib/notification';
 import Icon from 'antd/lib/icon';
 import AceEditor from 'react-ace';
+import * as $ from 'jquery';
+import Diff from 'react-diff';
+import { RaisedButton } from 'material-ui';
+import CircularProgress from 'material-ui/CircularProgress';
+import { Paper } from 'material-ui';
+import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
+import urls from '../../Utils/urls';
+import colors from '../../Utils/colors';
+
 import 'brace/mode/markdown';
 import 'brace/theme/github';
 import 'brace/theme/monokai';
@@ -16,14 +25,8 @@ import 'brace/theme/textmate';
 import 'brace/theme/solarized_dark';
 import 'brace/theme/solarized_light';
 import 'brace/theme/terminal';
-import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
-import * as $ from 'jquery';
-import { Paper } from 'material-ui';
-import Diff from 'react-diff';
+
 import './SkillHistory.css';
-import urls from '../../Utils/urls';
-import { RaisedButton } from 'material-ui';
-import colors from '../../Utils/colors';
 
 class SkillHistory extends Component {
     constructor(props) {
@@ -187,7 +190,12 @@ class SkillHistory extends Component {
         <div>
           <StaticAppBar {...this.props} />
           {this.state.commitData.length === 0 && (
-            <h1 className='skill_loading_container'>Loading...</h1>
+            <h1 className='skill_loading_container'>
+                <div className='center'>
+                  <CircularProgress size={62} color='#4285f5'/>
+                  <h4>Loading</h4>
+                </div>
+            </h1>
           )}
           <div style={styles.home}>
             {this.state.commitData.length === 2 && (<div style={{display:'block'}}>

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -15,6 +15,7 @@ import {
     Paper,
 } from 'material-ui';
 import Divider from 'material-ui/Divider';
+import CircularProgress from 'material-ui/CircularProgress';
 
 // Static Assets
 import 'brace/mode/markdown';
@@ -351,7 +352,16 @@ class SkillListing extends Component {
         let oldImageValue = this.state.imgUrl;
         let imageValue = this.state.image;
         if (!this.state.dataReceived) {
-            renderElement = <div><StaticAppBar {...this.props} /><h1 className='skill_loading_container'>Loading...</h1></div>
+            renderElement = <div>
+                    <StaticAppBar
+                    {...this.props} />
+                    <h1 className='skill_loading_container'>
+                        <div className='center'>
+                            <CircularProgress size={62} color='#4285f5'/>
+                            <h4>Loading</h4>
+                        </div>
+                    </h1>
+                </div>
         }
         else {
             renderElement = <div>

--- a/src/components/SkillRollBack/SkillRollBack.js
+++ b/src/components/SkillRollBack/SkillRollBack.js
@@ -1,6 +1,18 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import AceEditor from 'react-ace';
+import * as $ from 'jquery';
+import { Paper } from 'material-ui';
+import Diff from 'react-diff';
+import Cookies from 'universal-cookie';
+import Icon from 'antd/lib/icon';
+import notification from 'antd/lib/notification';
+import CircularProgress from 'material-ui/CircularProgress';
+
+import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
+import SkillEditor from '../SkillEditor/SkillEditor';
+import urls from '../../Utils/urls';
+
 import 'brace/mode/markdown';
 import 'brace/theme/github';
 import 'brace/theme/monokai';
@@ -13,15 +25,6 @@ import 'brace/theme/textmate';
 import 'brace/theme/solarized_dark';
 import 'brace/theme/solarized_light';
 import 'brace/theme/terminal';
-import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
-import * as $ from 'jquery';
-import {Paper} from 'material-ui';
-import Diff from 'react-diff';
-import Cookies from 'universal-cookie';
-import Icon from 'antd/lib/icon';
-import notification from 'antd/lib/notification';
-import SkillEditor from '../SkillEditor/SkillEditor';
-import urls from '../../Utils/urls';
 
 const cookies = new Cookies();
 
@@ -259,7 +262,12 @@ class SkillRollBack extends Component {
         <div>
           <StaticAppBar {...this.props} />
           {this.state.commitData.length === 0 && (
-            <h1 className='skill_loading_container'>Loading...</h1>
+            <h1 className='skill_loading_container'>
+              <div className='center'>
+                <CircularProgress size={62} color='#4285f5'/>
+                <h4>Loading</h4>
+              </div>
+            </h1>
           )}
           {this.state.commitData.length === 2 && (<div style={{display:'block'}}>
             <div style={styles.home}>

--- a/src/components/SkillVersion/SkillVersion.js
+++ b/src/components/SkillVersion/SkillVersion.js
@@ -12,6 +12,7 @@ import {
 } from 'material-ui/Table';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { RaisedButton } from 'material-ui';
+import CircularProgress from 'material-ui/CircularProgress';
 import { RadioButton } from 'material-ui/RadioButton';
 import notification from 'antd/lib/notification';
 import Icon from 'antd/lib/icon';
@@ -262,7 +263,12 @@ class SkillVersion extends Component {
                 <StaticAppBar {...this.props} />
                 {!this.state.dataReceived ?
                     (
-                        <h1 className='skill_loading_container'>Loading...</h1>
+                        <h1 className='skill_loading_container'>
+                            <div className='center'>
+                                <CircularProgress size={62} color='#4285f5'/>
+                                <h4>Loading</h4>
+                            </div>
+                        </h1>
                     )
                     :
                     (


### PR DESCRIPTION
Fixes #674 

Changes: Replaced loading text with circular loading animation like used in google apps.

Surge Deployment Link: https://pr-675-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/41230855-e17aae54-6d9e-11e8-9b1c-30a4e75a125f.png)
