### PR TITLE
Showing actual usage data from API

### DIFF
--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -206,18 +206,8 @@ class SkillListing extends Component {
     }
 
     saveSkillUsage = (skill_usage = []) => {
-        // Add sample data to test
-        const data = [
-              {date: '2018-06-05', count: 7},
-              {date: '2018-06-06', count: 2},
-              {date: '2018-06-07', count: 2},
-              {date: '2018-06-08', count: 2},
-              {date: '2018-06-09', count: 6},
-              {date: '2018-06-10', count: 2},
-              {date: '2018-06-11', count: 2},
-        ];
         this.setState({
-            skill_usage: data
+            skill_usage: skill_usage
         })
     }
 


### PR DESCRIPTION
Fixes 
Show actual skill usage data #685

Changes: 
Removed sample data and used actual data from the API to show in the usage chart.

Surge Deployment Link: https://susi--cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/10573038/41249377-9c62bf90-6dd1-11e8-812b-5c730ce63b52.png)
