### PR TITLE
pass theme settings to preview section locally - fix #669

### DIFF
--- a/public/BotAvatarPreview.html
+++ b/public/BotAvatarPreview.html
@@ -5,11 +5,14 @@
                 function addJS() {
                     var loc = location.href.split('?')[1].split('=');
                     var access = loc[1].split('&');
+                    var theme = loc[3].split('&');
+                    theme = decodeURIComponent(theme[0]);
                     const myscript = document.createElement('script');
                     myscript.type = 'text/javascript';
                     myscript.id = 'susi-bot-script';
                     myscript.setAttribute('data-token',access[0]);
-                    myscript.setAttribute('data-bot-type', loc[2]);
+                    myscript.setAttribute('data-bot-type', loc[2].split('&')[0]);
+                    myscript.setAttribute('data-theme', theme);
                     myscript.src = 'susi-chatbot.js';
                     myscript.async = true;
                     document.body.appendChild(myscript);

--- a/public/BotPreview.html
+++ b/public/BotPreview.html
@@ -5,11 +5,14 @@
             function addJS() {
                 var loc = location.href.split('?')[1].split('=');
                 var access = loc[1].split('&');
+                var theme = loc[3].split('&');
+                theme = decodeURIComponent(theme[0]);
                 const myscript = document.createElement('script');
                 myscript.type = 'text/javascript';
                 myscript.id = 'susi-bot-script';
                 myscript.setAttribute('data-token',access[0]);
-                myscript.setAttribute('data-bot-type', loc[2]);
+                myscript.setAttribute('data-bot-type', loc[2].split('&')[0]);
+                myscript.setAttribute('data-theme', theme);
                 myscript.src = 'susi-chatbot.js';
                 myscript.async = true;
                 document.body.appendChild(myscript);

--- a/public/susi-chatbot.js
+++ b/public/susi-chatbot.js
@@ -20,9 +20,9 @@ var flag = 0;
 if(bot_type){
 	flag = 1;
 }
+var theme_settings = script_tag.getAttribute("data-theme")?script_tag.getAttribute("data-theme"):null;
 
 // custom theme variables
-
 var botbuilderBackgroundBody = "#ffffff";
 var botbuilderBodyBackgroundImg = "";
 var botbuilderUserMessageBackground = "#0077e5";
@@ -45,32 +45,46 @@ if(typeof jQuery=='undefined') {
 
 // get custom theme from user
 function getTheme(){
-	$.ajax({
-		type: "GET",
-		url: "https://api.susi.ai/aaa/listUserSettings.json?access_token="+access_token,
-		jsonpCallback: 'pa',
-		contentType: "application/json",
-		dataType: 'jsonp',
-		jsonp: 'callback',
-		crossDomain: true,
-		success: function(data) {
-			if(data.settings){
-			let settings = data.settings;
-			botbuilderBackgroundBody = settings.botbuilderBackgroundBody?"#"+settings.botbuilderBackgroundBody:botbuilderBackgroundBody;
-			botbuilderBodyBackgroundImg = settings.botbuilderBodyBackgroundImg?settings.botbuilderBodyBackgroundImg:botbuilderBodyBackgroundImg;
-			botbuilderUserMessageBackground = settings.botbuilderUserMessageBackground?"#"+settings.botbuilderUserMessageBackground:botbuilderUserMessageBackground;
-			botbuilderUserMessageTextColor = settings.botbuilderUserMessageTextColor?"#"+settings.botbuilderUserMessageTextColor:botbuilderUserMessageTextColor;
-			botbuilderBotMessageBackground = settings.botbuilderBotMessageBackground?"#"+settings.botbuilderBotMessageBackground:botbuilderBotMessageBackground;
-			botbuilderBotMessageTextColor = settings.botbuilderBotMessageTextColor?"#"+settings.botbuilderBotMessageTextColor:botbuilderBotMessageTextColor;
-			botbuilderIconColor = settings.botbuilderIconColor?"#"+settings.botbuilderIconColor:botbuilderIconColor;
-			botbuilderIconImg = settings.botbuilderIconImg?settings.botbuilderIconImg:botbuilderIconImg;
-			applyTheme();
-		}
-		},
-		error: function(e) {
-			console.log(e);
-		}
-	});
+	if(theme_settings){
+		let settings = JSON.parse(theme_settings);
+		botbuilderBackgroundBody = settings.botbuilderBackgroundBody?settings.botbuilderBackgroundBody:botbuilderBackgroundBody;
+		botbuilderBodyBackgroundImg = settings.botbuilderBodyBackgroundImg?settings.botbuilderBodyBackgroundImg:botbuilderBodyBackgroundImg;
+		botbuilderUserMessageBackground = settings.botbuilderUserMessageBackground?settings.botbuilderUserMessageBackground:botbuilderUserMessageBackground;
+		botbuilderUserMessageTextColor = settings.botbuilderUserMessageTextColor?settings.botbuilderUserMessageTextColor:botbuilderUserMessageTextColor;
+		botbuilderBotMessageBackground = settings.botbuilderBotMessageBackground?settings.botbuilderBotMessageBackground:botbuilderBotMessageBackground;
+		botbuilderBotMessageTextColor = settings.botbuilderBotMessageTextColor?settings.botbuilderBotMessageTextColor:botbuilderBotMessageTextColor;
+		botbuilderIconColor = settings.botbuilderIconColor?settings.botbuilderIconColor:botbuilderIconColor;
+		botbuilderIconImg = settings.botbuilderIconImg?settings.botbuilderIconImg:botbuilderIconImg;
+		applyTheme();
+	}
+	else{
+		$.ajax({
+			type: "GET",
+			url: "https://api.susi.ai/aaa/listUserSettings.json?access_token="+access_token,
+			jsonpCallback: 'pa',
+			contentType: "application/json",
+			dataType: 'jsonp',
+			jsonp: 'callback',
+			crossDomain: true,
+			success: function(data) {
+				if(data.settings){
+				let settings = data.settings;
+				botbuilderBackgroundBody = settings.botbuilderBackgroundBody?"#"+settings.botbuilderBackgroundBody:botbuilderBackgroundBody;
+				botbuilderBodyBackgroundImg = settings.botbuilderBodyBackgroundImg?settings.botbuilderBodyBackgroundImg:botbuilderBodyBackgroundImg;
+				botbuilderUserMessageBackground = settings.botbuilderUserMessageBackground?"#"+settings.botbuilderUserMessageBackground:botbuilderUserMessageBackground;
+				botbuilderUserMessageTextColor = settings.botbuilderUserMessageTextColor?"#"+settings.botbuilderUserMessageTextColor:botbuilderUserMessageTextColor;
+				botbuilderBotMessageBackground = settings.botbuilderBotMessageBackground?"#"+settings.botbuilderBotMessageBackground:botbuilderBotMessageBackground;
+				botbuilderBotMessageTextColor = settings.botbuilderBotMessageTextColor?"#"+settings.botbuilderBotMessageTextColor:botbuilderBotMessageTextColor;
+				botbuilderIconColor = settings.botbuilderIconColor?"#"+settings.botbuilderIconColor:botbuilderIconColor;
+				botbuilderIconImg = settings.botbuilderIconImg?settings.botbuilderIconImg:botbuilderIconImg;
+				applyTheme();
+			}
+			},
+			error: function(e) {
+				console.log(e);
+			}
+		});
+	}
 }
 
 // to apply custom theme
@@ -123,10 +137,6 @@ function applyTheme(){
 	}
 }
 
-setInterval(function(){
-	getTheme();
-}, 2000);
-
 function enableBot(){
 	getTheme();
 	$(document).ready(function() {
@@ -173,7 +183,7 @@ function enableBot(){
 			'<div id="susi-launcher-container" class="susi-flex-center susi-avatar-launcher susi-launcher-enabled">'+
 			'<div id="susi-avatar-text">'+'Hey there'+'</div>'+
 			'<div id="susi-launcher" class="susi-launcher susi-flex-center susi-launcher-active" style="background-color: rgb(91, 75, 159);">'+
-			'<div id="susi-launcher-button" class="susi-launcher-button" style="background-image: url('+ susi_skills_deployed_url + 'avatar.jpg' +');">'+'</div>'+
+			'<div id="susi-launcher-button" class="susi-launcher-button" style="background-image: url('+ botbuilderIconImg +');">'+'</div>'+
 			'</div>'+
 			'</div>';
 		} else if (flag==1) {
@@ -185,7 +195,7 @@ function enableBot(){
 							'<div id="susi-chatbox" class="susi-chatbox">'+
 								'<div id="susi-conversation" class="susi-conversation susi-sheet susi-sheet-active susi-active">'+
 									'<div class="susi-sheet-content">'+
-										'<div class="susi-sheet-content-container" style="background-color:'+botbuilderBackgroundBody+'">'+
+										'<div class="susi-sheet-content-container" style="background-color:'+botbuilderBackgroundBody+';background-image:url('+botbuilderBodyBackgroundImg+')">'+
 											'<div class="susi-conversation-parts-container">'+
 												'<div id="susi-message" class="susi-conversation-parts">'+
 												'</div>'+
@@ -214,7 +224,7 @@ function enableBot(){
 				mybot = '<div id="susi-launcher-container" class="susi-flex-center susi-avatar-launcher susi-launcher-enabled">'+
 	            	'<div id="susi-avatar-text" style="display: block !important">'+'Hey there'+'</div>'+
 	            	'<div id="susi-launcher" class="susi-launcher susi-flex-center susi-launcher-active" style="background-color: rgb(91, 75, 159);">'+
-	                '<div id="susi-launcher-button" class="susi-launcher-button" style="background-image: url(avatar.jpg)">'+'</div>'+
+	                '<div id="susi-launcher-button" class="susi-launcher-button" style="background-image: url('+botbuilderIconImg+')">'+'</div>'+
 	            	'</div>'+
 	        		'</div>';
 			}

--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -98,6 +98,16 @@
 .icon-selected .bot-avatar{
 	border: solid 2px #4285f5;
 }
+iframe{
+moz-border-radius: 12px;
+webkit-border-radius: 12px;
+border-radius: 12px;
+max-width: 100%;
+margin:0;
+padding:0;
+border:1px solid #ccc;
+overflow:hidden;
+}
 @media (min-width:769px){
 	.botbuilder-page-wrapper{
 		padding: 40px 30px 30px;

--- a/src/components/BotBuilder/BotBuilder.js
+++ b/src/components/BotBuilder/BotBuilder.js
@@ -50,7 +50,6 @@ class BotBuilder extends React.Component {
                                                 label='Create your own SUSI AI Web bot'
                                                 backgroundColor={colors.header}
                                                 labelColor='#fff'
-                                                onClick={this.toggleCreateBotWizard}
                                             />
                                         </Link>
                                     </div>

--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -6,6 +6,7 @@ import Cookies from 'universal-cookie';
 import Snackbar from 'material-ui/Snackbar';
 import TiTick from 'react-icons/lib/ti/tick';
 import CircularProgress from 'material-ui/CircularProgress';
+import PropTypes from 'prop-types';
 import ColorPicker from 'material-ui-color-picker'
 import colors from '../../../Utils/colors';
 import urls from '../../../Utils/urls';
@@ -35,40 +36,45 @@ class Design extends React.Component {
         this.getSettings();
     }
 
+    componentDidMount(){
+        this.updateSettings();
+    }
+    updateSettings = () =>{
+        let settingsString = JSON.stringify(this.state);
+        this.props.updateSettings(settingsString);
+    }
     handleChangeColor = (component,color) =>{
         if(component === 'botbuilderIconColor'){
             this.setState({
                 [component]:color,
                 iconSelected:null,
                 botbuilderIconImg:''
-            });
+            },()=>this.updateSettings());
         }
         else {
             this.setState({
                 [component]:color
-            });
+            },()=>this.updateSettings());
         }
 
     }
 
     handleChangeBodyBackgroundImage = (botbuilderBodyBackgroundImg) =>{
-        this.setState({botbuilderBodyBackgroundImg});
+        this.setState({botbuilderBodyBackgroundImg},()=>this.updateSettings());
     }
     handleRemoveUrlBody = () =>{
-        this.setState({botbuilderBodyBackgroundImg:''});
+        this.setState({botbuilderBodyBackgroundImg:''},()=>this.updateSettings());
     }
     handleChangeIconImage = (botbuilderIconImg) =>{
         this.setState({
             botbuilderIconImg,
             iconSelected:null
-        });
+        },()=>this.updateSettings());
     }
     handleRemoveUrlIcon = () =>{
-        this.setState({botbuilderIconImg:''});
+        this.setState({botbuilderIconImg:''},()=>this.updateSettings());
     }
-    implementSettings = () =>{
-        // implement settings locally
-    }
+
     handleSave = () =>{
         // send settings to server
         if(cookies.get('loggedIn')===null||
@@ -198,7 +204,7 @@ class Design extends React.Component {
 
                     this.setState({
                         loadedSettings:true
-                    });
+                    },()=>this.updateSettings());
                     let botbuilderIconImg = settings.botbuilderIconImg;
                     if(botbuilderIconImg){
                         for(let icon of avatars){
@@ -280,7 +286,7 @@ class Design extends React.Component {
                     resetting:false,
                     openSnackbar:true,
                     msgSnackbar:'Success! Saved settings'
-                });
+                },()=>this.updateSettings());
             }.bind(this),
             error: function (textStatus, errorThrown) {
                 this.setState({
@@ -297,13 +303,13 @@ class Design extends React.Component {
             this.setState({
                 iconSelected:null,
                 botbuilderIconImg:''
-            })
+            },()=>this.updateSettings())
         }
         else{
             this.setState({
                 iconSelected:icon.id,
                 botbuilderIconImg:icon.url
-            })
+            },()=>this.updateSettings())
         }
 
     }
@@ -410,6 +416,7 @@ class Design extends React.Component {
 
 
         Design.propTypes = {
+                updateSettings: PropTypes.function
         };
 
         export default Design;

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -13,16 +13,16 @@ import './BotBuilder.css';
 import Cookies from 'universal-cookie';
 
 const cookies = new Cookies();
-const locationBot = '/BotPreview.html?access='+cookies.get('loggedIn')+'&type=botWindow';
-const locationAvatar = '/BotAvatarPreview.html?access='+cookies.get('loggedIn')+'&type=botAvatar';
 
-class ContactBot extends React.Component {
+
+class BotWizard extends React.Component {
 
     constructor(props){
         super(props);
         this.state = {
             finished: false,
-            stepIndex: 0
+            stepIndex: 0,
+            themeSettingsString:'{}'
         }
     }
 
@@ -41,12 +41,16 @@ class ContactBot extends React.Component {
         }
     };
 
+    updateSettings = (themeSettingsString) =>{
+        this.setState({themeSettingsString})
+    }
+
     getStepContent(stepIndex) {
         switch (stepIndex) {
             case 0:
                 return <Build />;
             case 1:
-                return <Design />;
+                return <Design updateSettings={this.updateSettings} />;
             case 2:
                 return <Configure />;
             case 3:
@@ -58,10 +62,13 @@ class ContactBot extends React.Component {
     setStep = (stepIndex) =>{
         this.setState({stepIndex});
     }
-
 	render() {
         const {stepIndex} = this.state;
         const contentStyle = {margin: '0 16px'};
+        const locationAvatar = '/BotAvatarPreview.html?access='+cookies.get('loggedIn')+'&type=botAvatar'+
+        '&themeSettings='+encodeURIComponent(this.state.themeSettingsString);
+        const locationBot = '/BotPreview.html?access='+cookies.get('loggedIn')+'&type=botWindow'+
+        '&themeSettings='+encodeURIComponent(this.state.themeSettingsString);
 		return (
 			<div>
 				<StaticAppBar {...this.props} />
@@ -69,9 +76,8 @@ class ContactBot extends React.Component {
 					<Paper style={styles.paperStyle} className="botBuilder-page-card" zDepth={1}>
                         <Grid>
                             <Row>
-                                <div style={{display: 'flex', 'flex-direction':window.innerWidth>769?'row':'column'}}>
                                 <Col xs={12} md={8} lg={8}>
-                                    <div style={{width: '100%', 'max-width': '100%', margin: 'auto'}}>
+                                    <div style={{width: '100%', maxWidth: '100%', margin: 'auto'}}>
                                         <Stepper activeStep={stepIndex} linear={false}>
                                             <Step>
                                                 <StepButton onClick={()=>this.setStep(0)}>
@@ -95,7 +101,7 @@ class ContactBot extends React.Component {
                                             </Step>
                                         </Stepper>
                                         <div style={contentStyle}>
-                                            <p>{this.getStepContent(stepIndex)}</p>
+                                            <div>{this.getStepContent(stepIndex)}</div>
                                             <div style={{marginTop: '20px'}}>
                                                 <RaisedButton
                                                     label="Back"
@@ -119,15 +125,14 @@ class ContactBot extends React.Component {
                                         </div>
                                     </div>
                                 </Col>
-                                <Col xs={12} md={4} lg={4} style={{textAlign:window.innerWidth>769?'right':'left', borderLeft:'1px solid rgb(66, 133, 244)', padding:'0.01em 16px'}}>
+                                <Col xs={12} md={4} lg={4} style={{textAlign:'center', padding:'0.01em 16px'}}>
                                     <br className='display-mobile-only'/>
-                                    <h2 style={{padding:'10px 0 10px 10px', textAlign:'left'}}>Preview</h2><br/>
+                                <h2 className='center'>Preview</h2><br/>
                                     <div style={{position:'relative', overflow:'hidden'}}>
-                                        <iframe title="botPreview" name="frame-name" id="frame-1" src={locationBot} height="600px" style={styles.iframe}></iframe>
-                                        <iframe title="botAvatarPreview" name="frame-2" id="frame-2" src={locationAvatar} height="100px" style={styles.iframe}></iframe>
+                                        <iframe title="botPreview" name="frame-name" id="frame-1" src={locationBot} height="600px"></iframe>
+                                        <iframe title="botAvatarPreview" name="frame-2" id="frame-2" src={locationAvatar} height="100px"></iframe>
                                     </div>
                                 </Col>
-                                </div>
                             </Row>
                         </Grid>
 					</Paper>
@@ -151,17 +156,7 @@ const styles = {
     },
     tabStyle: {
         color:'rgb(91, 91, 91)'
-    },
-    iframe: {
-        '-moz-border-radius': '12px',
-        '-webkit-border-radius': '12px',
-        'border-radius': '12px',
-        'max-width': '100%',
-        margin:'0',
-        padding:'0',
-        border:'1px solid #ccc',
-        overflow:'hidden'
     }
 };
 
-export default ContactBot;
+export default BotWizard;


### PR DESCRIPTION
Fixes #669

Changes: 
- avoid fetching theme from server every 2 secs in the `susi-chatbot.js` file.
- save theme settings in the `state` of `BotWizard` component. 
- Above settings is updated from the `Design` component whenever the user updates any settings. *Thus giving the feature of live preview.*
- pass the theme settings to the `susi-chatbot.js` file through get parameters and extract it there.
- fix small bugs and remove console errors.

Surge Deployment Link: https://pr-689-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![susi design dynamic](https://user-images.githubusercontent.com/17807257/41260105-bab99adc-6df3-11e8-8554-682f561a26be.gif)
