### PR TITLE
Fixes #599: Display weekly skill hits count in skill usage section

### DIFF
--- a/src/components/SkillUsageCard/SkillUsage.css
+++ b/src/components/SkillUsageCard/SkillUsage.css
@@ -1,0 +1,25 @@
+.usage-section {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-wrap: wrap;
+    margin: 24px;
+}
+
+.skill-usage-chart {
+    flex: 3;
+    margin: 16px 32px 16px 16px;
+    padding: 20px;
+}
+
+.usage-section div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.total-hits {
+  display: flex;
+  flex-direction: column;
+  padding: 24px 48px 24px 48px;
+}

--- a/src/components/SkillUsageCard/SkillUsageCard.js
+++ b/src/components/SkillUsageCard/SkillUsageCard.js
@@ -4,22 +4,38 @@ import PropTypes from 'prop-types';
 import { LineChart, Line, XAxis, YAxis, Tooltip, Legend } from 'recharts';
 import { Paper } from 'material-ui';
 
+// Static assets
+import './SkillUsage.css';
+
 class SkillUsageCard extends Component {
 	render() {
+
+		const totalSkillUsage = this.props.skill_usage.reduce((totalCount, day) => {
+			return totalCount + day.count
+		}, 0);
+
 		return(
 			<Paper className="margin-b-md margin-t-md">
 				<h1 className='title'>
 					Skill Usage
 				</h1>
-				<div className="skill-usage-graph">
-					<LineChart width={600} height={300} data={this.props.skill_usage}
-							margin={{top: 5, right: 30, left: 20, bottom: 5}}>
-						<XAxis dataKey="date" padding={{right: 20}} />
-						<YAxis/>
-						<Tooltip wrapperStyle={{height: '60px'}}/>
-						<Legend />
-						<Line name='Skill usage count' type="monotone" dataKey="count" stroke="#82ca9d" activeDot={{r: 8}}/>
-					</LineChart>
+				<div className="usage-section">
+					<div className="skill-usage-chart">
+						<LineChart width={600} height={300} data={this.props.skill_usage}
+								margin={{top: 5, right: 30, left: 20, bottom: 5}}>
+							<XAxis dataKey="date" padding={{right: 20}} />
+							<YAxis/>
+							<Tooltip wrapperStyle={{height: '60px'}}/>
+							<Legend />
+							<Line name='Skill usage count' type="monotone" dataKey="count" stroke="#82ca9d" activeDot={{r: 8}}/>
+						</LineChart>
+					</div>
+					<div className="total-hits">
+						<div className="large-text">
+							{totalSkillUsage}
+						</div>
+						Hits this week
+					</div>
 				</div>
 			</Paper>
 		)


### PR DESCRIPTION
Fixes #599 

Changes: Display weekly skill hits count in skill usage section

Surge Deployment Link: https://pr-702-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/41334105-f295bc9c-6f01-11e8-95eb-be11c6a12c09.png)
