### PR TITLE
Add conversation view in botbuilder (basic first version)

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.css
+++ b/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.css
@@ -1,0 +1,25 @@
+.user-text-box {
+    background-color: #e0e0e0;
+    font-size: 14px;
+    padding: 20px;
+    text-align: right;
+    max-width: 60%;
+    min-width: 60px;
+    margin-right: 10px;
+    margin-left: auto;
+    margin-bottom: 15px;
+    border-radius: 12px;
+}
+
+.bot-text-box {
+    background-color: #F5F5F5;
+    font-size: 14px;
+    padding: 20px;
+    text-align: left;
+    max-width: 60%;
+    min-width: 60px;
+    margin-right: auto;
+    margin-left: 10px;
+    margin-bottom: 15px;
+    border-radius: 12px;
+}

--- a/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.js
+++ b/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.js
@@ -1,23 +1,106 @@
 import React, {Component} from 'react';
+import colors from '../../../../Utils/colors';
+import { Paper } from 'material-ui';
+import RaisedButton from 'material-ui/RaisedButton';
+import $ from 'jquery';
+import './ConversationView.css';
 
 class ConversationView extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: 'Enter text here',
+            textType: 'user'
+        };
+        this.handleChange = this.handleChange.bind(this);
+        this.handleSubmit = this.handleSubmit.bind(this);
+    }
 
-  constructor(props) {
-    super(props);
-    this.state = {
-    };
-  }
+    handleChange(event) {
+        this.setState({value: event.target.value});
+    }
 
-  componentDidMount(){
-  }
-  render() {
-    return (
-      <div className='menu-page'>
-        <div>
-        </div>
-      </div>
-    );
-  }
+    handleSubmit(event) {
+        console.log('The text is: ' + this.state.value);
+        if(this.state.textType === 'user') {
+            this.handleUserText(this.state.value);
+        } else if(this.state.textType === 'bot') {
+            this.handleBotText(this.state.value);
+        }
+        $('#text-box').val('');
+        if (this.state.textType === 'bot') {
+            this.setState({textType: 'user'});
+        } else if (this.state.textType === 'user') {
+            this.setState({textType: 'bot'});
+        }
+        event.preventDefault();
+    }
+
+    handleUserText = (text) => {
+        var userText = document.createElement('div');
+        userText.className = 'user-text-box';
+        userText.innerHTML = text;
+        $('#message-container').append(userText);
+    }
+
+    handleBotText = (text) => {
+        var botText = document.createElement('div');
+        botText.className = 'bot-text-box';
+        botText.innerHTML = text;
+        $('#message-container').append(botText);
+    }
+
+    render() {
+        return(
+            <div style={{padding: '10px 10px 20px 10px'}}>
+                <Paper id="message-container" style={styles.paperStyle} zDepth={1}>
+                </Paper>
+                <form onSubmit={this.handleSubmit} style={{marginTop: '15px'}}>
+                    <label>
+                        {(this.state.textType==='user')?(<div style={{fontSize:'14px'}}>Type the user message:</div>):(<div style={{fontSize:'14px'}}>Type the bot response:</div>)}
+                        <input id='text-box' type="text" placeholder={(this.state.textType==='user')?('Enter the user message'):('Enter the bot response')} onChange={this.handleChange} style={styles.textBox}/>
+                    </label>
+                    <RaisedButton
+                        label="Submit"
+                        backgroundColor={colors.header}
+                        labelColor='#fff'
+                        onTouchTap={this.handleSubmit}
+                        style={{marginTop: 10}}
+                    />
+                </form>
+            </div>
+        );
+    }
+}
+
+const styles = {
+    textBox: {
+        width: '100%',
+        fontSize: '14px',
+        padding: '12px 20px',
+        margin: '8px 0',
+        display: 'inline-block',
+        border: '1px solid #ccc',
+        borderRadius: '4px',
+        boxSizing: 'border-box'
+    },
+    paperStyle: {
+        width: '100%',
+        padding: '20px 20px 20px 20px'
+    },
+    submitButton: {
+        width: '40px',
+        backgroundColor: 'rgb(66, 133, 244)',
+        color: 'white',
+        padding: '14px 20px',
+        margin: '8px 0',
+        border: 'none',
+        borderRadius: '4px',
+        cursor: 'pointer'
+    },
+    icon: {
+        verticleAlign: 'middle'
+    }
 }
 
 export default ConversationView;


### PR DESCRIPTION
Partially fixes issue #576 

Changes: This provides a text box for bot creator to set the bot response for a particular user message.

Next steps:
- Add icons for bot and user.
- Give option to delete a bot message or user message.
- Give option to save a small conversation and then show it in a list form. In other words, manage the conversation. (I'll share mockups once I'm done with previous two steps).

Further steps:
- Improve UI
- Sync all the three views i.e. Code view, conversation view and tree view with each other.
- Sync all the three views with server.

Surge Deployment Link: https://pr-703-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

![jun-13-2018 15-40-52](https://user-images.githubusercontent.com/31174685/41345465-57158976-6f21-11e8-96b6-c0e6e9ed2e09.gif)
