### PR TITLE
Enable click on color box in botbuilder

### DIFF
--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -66,6 +66,7 @@
 	display: inline-block;
 	border-radius: 3px;
 	border: solid 1px #0000006e;
+	cursor: pointer;
 }
 .color-picker-wrap>div{
 	display: inline-block;

--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -308,6 +308,10 @@ class Design extends React.Component {
 
     }
 
+    handleClickColorBox = (id) =>{
+        $('#colorPicker' + id).click();
+    }
+
     render() {
         // Custom Theme feature Component
         const customiseOptionsList = [
@@ -326,11 +330,13 @@ class Design extends React.Component {
                             className='color-picker'
                             style={{display:'inline-block',float:'left'}}
                             name='color'
+                            id={'colorPicker'+component.id}
                             defaultValue={ this.state[component.component] }
                             onChange={(color)=>
                                 this.handleChangeColor(component.component,color) }
                         />
-                    <span className='color-box' style={{backgroundColor:this.state[component.component]}}></span>
+                    <span className='color-box' onClick={()=>this.handleClickColorBox(component.id)}
+                        style={{backgroundColor:this.state[component.component]}}></span>
                     </div>
                     {component.component === 'botbuilderBackgroundBody' && <div>
                         <TextField


### PR DESCRIPTION
Fixes #707 

Changes: 
- open the corresponding color picker when the user clicks on the color box on the right.

Surge Deployment Link: https://pr-708-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![color box click](https://user-images.githubusercontent.com/17807257/41365318-b8c26470-6f56-11e8-9686-4c4098795cdb.gif)
