### PR TITLE
Fixes #699: Add chip component to examples card

### DIFF
--- a/src/components/SkillPage/SkillListing.css
+++ b/src/components/SkillPage/SkillListing.css
@@ -44,14 +44,6 @@ abbr[title] {
     margin-top:10px ;
 }
 
-.exampleTile {
-  width: 200px;
-  margin-right: 20px;
-  box-shadow: none;
-  padding: 20px;
-  color: #555;
-}
-
 .margin-b-md {
     margin-bottom: 24px;
 }

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -16,6 +16,7 @@ import { FloatingActionButton, Paper } from 'material-ui';
 import Divider from 'material-ui/Divider';
 import CircularProgress from 'material-ui/CircularProgress';
 import Snackbar from 'material-ui/Snackbar';
+import Chip from 'material-ui/Chip';
 
 // Static Assets
 import 'brace/mode/markdown';
@@ -452,6 +453,13 @@ class SkillListing extends Component {
         marginBottom: 10,
         display: 'inline-block',
       },
+      chip: {
+        margin: '6px 6px 6px 0',
+        border: '1px solid #ccc',
+      },
+      chipLabel: {
+        fontWeight: 500,
+      },
     };
     let renderElement = null;
     let oldGroupValue = this.props.location.pathname.split('/')[1];
@@ -567,14 +575,14 @@ class SkillListing extends Component {
                     ? ''
                     : this.state.examples.map((data, index) => {
                         return (
-                          <Paper
+                          <Chip
                             key={index}
-                            className="exampleTile"
-                            style={{ backgroundColor: '#f5f5f5' }}
-                            zDepth={1}
+                            style={styles.chip}
+                            labelStyle={styles.chipLabel}
+                            backgroundColor={'#FFFFFF'}
                           >
                             {data}
-                          </Paper>
+                          </Chip>
                         );
                       })}
                 </div>


### PR DESCRIPTION
Fixes #699 

Changes: [Add here what changes were made in this issue and if possible provide links.]
Add chip component to examples card

Surge Deployment Link: https://pr-711-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot from 2018-06-14 13-13-00](https://user-images.githubusercontent.com/12656846/41398352-b73cf420-6fd4-11e8-83b0-f8ccff2cda58.png)

