### PR TITLE
Fixes #664 : Add feature to test skill example on chat.susi.ai

### DIFF
--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -432,6 +432,11 @@ class SkillListing extends Component {
     }
   };
 
+  testExample = (e, exampleText) => {
+    let link = 'https://chat.susi.ai/?testExample=' + exampleText;
+    window.open(link, '_blank');
+  };
+
   render() {
     const authorStyle = {
       cursor: 'pointer',
@@ -456,6 +461,7 @@ class SkillListing extends Component {
       chip: {
         margin: '6px 6px 6px 0',
         border: '1px solid #ccc',
+        cursor: 'pointer',
       },
       chipLabel: {
         fontWeight: 500,
@@ -580,6 +586,7 @@ class SkillListing extends Component {
                             style={styles.chip}
                             labelStyle={styles.chipLabel}
                             backgroundColor={'#FFFFFF'}
+                            onClick={event => this.testExample(event, data)}
                           >
                             {data}
                           </Chip>


### PR DESCRIPTION
Fixes #664 

Changes: [Add here what changes were made in this issue and if possible provide links.]
 Add feature to test skill example on chat.susi.ai by clicking on Skill examples on the skills page

Surge Deployment Link: 
https://testexample.surge.sh/

Screenshots for the change:
![ezgif-5-504e9db55c](https://user-images.githubusercontent.com/12656846/41424711-756ff860-701c-11e8-8c48-226b05658f94.gif)


* Can be merged after #711 only.