### PR TITLE
Add loading animation in design section of botbuilder

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -11,6 +11,7 @@ import ColorPicker from 'material-ui-color-picker';
 import colors from '../../../Utils/colors';
 import urls from '../../../Utils/urls';
 import avatars from '../../../Utils/avatars';
+
 const cookies = new Cookies();
 let BASE_URL = urls.API_URL;
 
@@ -484,33 +485,40 @@ class Design extends React.Component {
     });
     return (
       <div className="center menu-page">
-        <div className="design-box">
-          {this.state.loadedSettings && customizeComponents}
-          <RaisedButton
-            label={
-              this.state.resetting ? (
-                <CircularProgress color={colors.header} size={32} />
-              ) : (
-                'Reset'
-              )
-            }
-            onTouchTap={this.handleReset}
-          />
-          <RaisedButton
-            name="save"
-            style={{ marginLeft: '15px' }}
-            backgroundColor={colors.header}
-            onTouchTap={this.handleSave}
-            labelColor="#fff"
-            label={
-              this.state.saving ? (
-                <CircularProgress color="#ffffff" size={32} />
-              ) : (
-                'Save Changes'
-              )
-            }
-          />
-        </div>
+        {!this.state.loadedSettings ? (
+          <div className="center">
+            <CircularProgress size={62} color="#4285f5" />
+            <h4>Loading</h4>
+          </div>
+        ) : (
+          <div className="design-box">
+            {this.state.loadedSettings && customizeComponents}
+            <RaisedButton
+              label={
+                this.state.resetting ? (
+                  <CircularProgress color={colors.header} size={32} />
+                ) : (
+                  'Reset'
+                )
+              }
+              onTouchTap={this.handleReset}
+            />
+            <RaisedButton
+              name="save"
+              style={{ marginLeft: '15px' }}
+              backgroundColor={colors.header}
+              onTouchTap={this.handleSave}
+              labelColor="#fff"
+              label={
+                this.state.saving ? (
+                  <CircularProgress color="#ffffff" size={32} />
+                ) : (
+                  'Save Changes'
+                )
+              }
+            />
+          </div>
+        )}
         <Snackbar
           open={this.state.openSnackbar}
           message={this.state.msgSnackbar}
@@ -525,7 +533,7 @@ class Design extends React.Component {
 }
 
 Design.propTypes = {
-  updateSettings: PropTypes.function,
+  updateSettings: PropTypes.func,
 };
 
 export default Design;


### PR DESCRIPTION
Fixes #714 

Changes: 
- add loading animation while the settings are being loaded. 

Surge Deployment Link: https://pr-715-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![design loading animation](https://user-images.githubusercontent.com/17807257/41414392-7627f154-7003-11e8-83e0-8fac46b5af4b.gif)
