### PR TITLE
Fixed issues with displaying total weekly hits of a skill

### DIFF
--- a/src/components/SkillUsageCard/SkillUsageCard.js
+++ b/src/components/SkillUsageCard/SkillUsageCard.js
@@ -29,10 +29,10 @@ class SkillUsageCard extends Component {
   };
 
   render() {
-    const totalSkillUsage = 0;
+    let totalSkillUsage = 0;
     if (this.props.skill_usage) {
       totalSkillUsage = this.props.skill_usage.reduce((totalCount, day) => {
-        return totalCount + day.count;
+        return parseInt(totalCount, 10) + parseInt(day.count, 10);
       }, 0);
     }
 


### PR DESCRIPTION
Fixes #717 

**Changes:** Fixed issues with displaying total weekly hits of a skill.

**Surge Deployment Link:** https://pr-720-fossasia-susi-skill-cms.surge.sh

**Screenshots for the change:**

For example, for the skill `aboutsusi`:

**Before:**
![totalhitsold](https://user-images.githubusercontent.com/31135861/41429089-a1fd7dfa-7029-11e8-9c18-8216feb1c906.png)

**After:**
![totalhitsnew](https://user-images.githubusercontent.com/31135861/41429093-a49ba2d0-7029-11e8-8b0d-83535f7ea059.png)
