### PR TITLE
Make conversation dynamic and add delete feature in conversation view

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.css
+++ b/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.css
@@ -6,7 +6,6 @@
     max-width: 60%;
     min-width: 60px;
     margin-right: 10px;
-    margin-left: auto;
     margin-bottom: 15px;
     border-radius: 12px;
 }
@@ -18,7 +17,6 @@
     text-align: center;
     max-width: 60%;
     min-width: 60px;
-    margin-right: auto;
     margin-left: 10px;
     margin-bottom: 15px;
     border-radius: 12px;

--- a/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.js
+++ b/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.js
@@ -2,71 +2,103 @@ import React, { Component } from 'react';
 import colors from '../../../../Utils/colors';
 import { Paper } from 'material-ui';
 import RaisedButton from 'material-ui/RaisedButton';
+import Snackbar from 'material-ui/Snackbar';
 import Person from 'material-ui/svg-icons/social/person';
-import $ from 'jquery';
+import Delete from 'material-ui/svg-icons/action/delete';
 import './ConversationView.css';
+
+let conversation = [],
+  indexConv = 0;
 
 class ConversationView extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      value: 'Enter text here',
+      value: '',
       textType: 'user',
+      textBoxValue: '',
+      openSnackbar: false,
+      msgSnackbar: '',
     };
     this.handleChange = this.handleChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleDelete = this.handleDelete.bind(this);
   }
 
   handleChange(event) {
-    this.setState({ value: event.target.value });
+    this.setState({
+      value: event.target.value,
+      textBoxValue: event.target.value,
+    });
+  }
+
+  handleDelete(event) {
+    this.setState({
+      openSnackbar: true,
+      msgSnackbar: 'Text successfully deleted!',
+    });
   }
 
   handleSubmit(event) {
-    console.log('The text is: ' + this.state.value);
-    if (this.state.textType === 'user') {
-      this.handleUserText(this.state.value);
-    } else if (this.state.textType === 'bot') {
-      this.handleBotText(this.state.value);
+    if (this.state.value !== '') {
+      this.handleTexts(this.state.textType, indexConv);
+      if (this.state.textType === 'bot') {
+        this.setState({ textType: 'user' });
+      } else if (this.state.textType === 'user') {
+        this.setState({ textType: 'bot' });
+      }
+      this.setState({ textBoxValue: '', value: '' });
+      event.preventDefault();
     }
-    $('#text-box').val('');
-    if (this.state.textType === 'bot') {
-      this.setState({ textType: 'user' });
-    } else if (this.state.textType === 'user') {
-      this.setState({ textType: 'bot' });
-    }
-    event.preventDefault();
   }
 
-  handleUserText = text => {
-    var userText = document.createElement('div');
-    userText.className = 'user-text-box';
-    userText.innerHTML = text;
-    $('#message-container').append(userText);
-  };
-
-  handleBotText = text => {
-    var botText = document.createElement('div');
-    botText.className = 'bot-text-box';
-    botText.innerHTML = text;
-    $('#message-container').append(botText);
-  };
-
-  render() {
-    return (
-      <div style={{ padding: '10px 10px 20px 10px' }}>
-        <Paper id="message-container" style={styles.paperStyle} zDepth={1}>
+  handleTexts = (type, i) => {
+    switch (type) {
+      case 'user':
+        conversation.push(
           <div style={{ display: 'flex', flexDirection: 'row' }}>
-            <div className="user-text-box">Hello</div>
+            <Delete
+              style={styles.deleteUser}
+              onClick={() => {
+                conversation[i] = <div />;
+                this.handleDelete();
+              }}
+            />
+            <div className="user-text-box">{this.state.value}</div>
             <Person style={{ height: '40px' }} />
-          </div>
+          </div>,
+        );
+        ++indexConv;
+        break;
+      case 'bot':
+        conversation.push(
           <div style={{ display: 'flex', flexDirection: 'row' }}>
             <img
               src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIISURBVFhH7di/S5VRHMfxa0RG0A+kKCGkIkhHazEKatAGB0EhCIeQhgajbBBqqSmJgiASKxpqkNZwcBBdRHELyoZESpD8A5QITNT0/TG/8CXO/eG9Hp8LPR94Dc+X5+F8eTj3nPPczP+U43iHGxtXZZinWMMyKlUot7yEGpSDKpRDDuAORvAL1uAUXuEcEksH5mFNZfMBR7FjqcALhJrJ5gfOYEfyAKEm8lGTVYgazakVhBooxHtEzQBssFk046GreZNoQq+rraIOUXII/u31wPITVje3oOyHrz9ClLTAD/Qdl9Dtat5HnMcTV5MJREkn/EDFmkOU3EdoQHmDWpzapLm5gNC9qkdJA+5lEVo+WhG69y7SlEVOQyeUL5iJ4BuGcB27sKVcxW+EJnkMw9iHgnIWS7CHtWNk+0WWYhqL7rofBUXHI3uoCzq9jLvadrmIk1Cjuv4DLVV5YwdPv+LHalDxO9RtFXLF75uvVdhMzAZPwGp+fw9G3xJ2s37BlpgN1sBqj1XIlbRBp6gG98DWPz8fYjaol6KDrGraq/OmDc9xeOPqb8bw7wClugBLO56h6O/pPoQGKZY2Av8CSs4xfEZosK1Sczex7dmNejSW4DKOII1lL+yYH6KpkWi0VITmmRlEotH/LaHGjP7QTDQ6CX9CqDm5gsRTjbf4CjvOj+Ia0qTJnUxmHfGs+A6k/UOLAAAAAElFTkSuQmCC"
               alt="bot icon"
               style={styles.botIcon}
             />
-            <div className="bot-text-box">Hi! I&apos;m SUSI.</div>
-          </div>
+            <div className="bot-text-box">{this.state.value}</div>
+            <Delete
+              style={styles.deleteBot}
+              onClick={() => {
+                conversation[i] = <div />;
+                this.handleDelete();
+              }}
+            />
+          </div>,
+        );
+        ++indexConv;
+        break;
+      default:
+    }
+  };
+
+  render() {
+    return (
+      <div style={{ padding: '10px 10px 20px 10px' }}>
+        <Paper id="message-container" style={styles.paperStyle} zDepth={1}>
+          {conversation}
         </Paper>
         <form onSubmit={this.handleSubmit} style={{ marginTop: '15px' }}>
           <label>
@@ -83,6 +115,7 @@ class ConversationView extends Component {
                   ? 'Enter the user message'
                   : 'Enter the bot response'
               }
+              value={this.state.textBoxValue}
               onChange={this.handleChange}
               style={styles.textBox}
             />
@@ -95,6 +128,14 @@ class ConversationView extends Component {
             style={{ marginTop: 10 }}
           />
         </form>
+        <Snackbar
+          open={this.state.openSnackbar}
+          message={this.state.msgSnackbar}
+          autoHideDuration={2000}
+          onRequestClose={() => {
+            this.setState({ openSnackbar: false });
+          }}
+        />
       </div>
     );
   }
@@ -130,6 +171,22 @@ const styles = {
     paddingTop: '9px',
     width: '21px',
     color: 'rgba(0, 0, 0, 0.87)',
+  },
+  deleteUser: {
+    height: '33px',
+    marginLeft: 'auto',
+    paddingTop: '10px',
+    paddingRight: '10px',
+    width: '32px',
+    cursor: 'pointer',
+  },
+  deleteBot: {
+    height: '31px',
+    marginRight: 'auto',
+    paddingTop: '8px',
+    paddingLeft: '10px',
+    width: '32px',
+    cursor: 'pointer',
   },
 };
 


### PR DESCRIPTION
Fixes #576 

Changes: 
- Made it possible to add conversations dynamically using react only. Completely removed usage of jQuery.
- Added delete feature to delete texts.

**Note: I was facing some problems in making delete button appear only on hover. I'll add this in next PR.**

Next steps (for upcoming PR):
- Currently, bot and user text mode switches alternatively. So, I'll add option to choose which conversation does bot creator want to happen next (bot or user). In other words, add option to add multiple bot texts or user texts rather than just a single text.
- Add hover property for delete button.

Surge Deployment Link: https://pr-735-fossasia-susi-skill-cms.surge.sh

![jun-16-2018 00-16-51](https://user-images.githubusercontent.com/31174685/41484482-a2b6e034-70fa-11e8-8a39-38fad4854521.gif)
