### PR TITLE
Rearrange hamburger menu

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -14,6 +14,7 @@ import MoreVertIcon from 'material-ui/svg-icons/navigation/more-vert';
 import Popover from 'material-ui/Popover';
 import Exit from 'material-ui/svg-icons/action/exit-to-app';
 import Extension from 'material-ui/svg-icons/action/extension';
+import Assessment from 'material-ui/svg-icons/action/assessment';
 import LoginIcon from 'material-ui/svg-icons/action/account-circle';
 import Info from 'material-ui/svg-icons/action/info';
 import Chat from 'material-ui/svg-icons/communication/chat';
@@ -31,15 +32,17 @@ const cookies = new Cookies();
 
 let TopRightMenuItems = props => (
   <div>
-    <MenuItem href="http://chat.susi.ai/overview" rightIcon={<Info />}>
-      About
-    </MenuItem>
     <MenuItem href="http://chat.susi.ai/" rightIcon={<Chat />}>
       Chat
     </MenuItem>
     <Link to="/">
       <MenuItem rightIcon={<SKillIcon />}>Skills</MenuItem>
     </Link>
+    {!cookies.get('loggedIn') ? (
+      <MenuItem href="http://chat.susi.ai/overview" rightIcon={<Info />}>
+        About
+      </MenuItem>
+    ) : null}
   </div>
 );
 
@@ -254,22 +257,35 @@ class StaticAppBar extends Component {
             targetOrigin={{ horizontal: 'right', vertical: 'top' }}
             onRequestClose={this.closeOptions}
           >
-            <TopRightMenuItems />
             {this.state.showAdmin === true ? (
               <MenuItem
                 primaryText="Admin"
                 containerElement={<Link to="/admin" />}
                 rightIcon={<List />}
               />
-            ) : (
-              console.log('Admin page allowed ' + cookies.get('showAdmin'))
-            )}
+            ) : null}
             {cookies.get('loggedIn') ? (
               <MenuItem
                 primaryText="Dashboard"
                 containerElement={<Link to="/dashboard" />}
+                rightIcon={<Assessment />}
+              />
+            ) : null}
+            <TopRightMenuItems />
+            {cookies.get('loggedIn') ? (
+              <MenuItem
+                primaryText="Botbuilder"
+                containerElement={<Link to="/botbuilder" />}
                 rightIcon={<Extension />}
               />
+            ) : null}
+            {cookies.get('loggedIn') ? (
+              <MenuItem
+                href="http://chat.susi.ai/overview"
+                rightIcon={<Info />}
+              >
+                About
+              </MenuItem>
             ) : null}
             {cookies.get('loggedIn') ? (
               <MenuItem


### PR DESCRIPTION
Fixes #742 

Changes: 
- Added "Dashboard" to the top.
- "About" is on the bottom just above logout.
- "Botbuilder" is at the current place of "Dashboard".

Surge Deployment Link: https://pr-755-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Not logged in:
<img width="138" alt="screen shot 2018-06-16 at 6 42 33 pm" src="https://user-images.githubusercontent.com/31174685/41498861-399059a0-7195-11e8-8b6d-9bd4d95a903d.png">

Logged in:
<img width="284" alt="screen shot 2018-06-16 at 6 42 51 pm" src="https://user-images.githubusercontent.com/31174685/41498863-3c8986cc-7195-11e8-8671-9be60faeda2f.png">

