### PR TITLE
Fixes #753: Show top rated skills by default

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -43,8 +43,7 @@ export default class BrowseSkill extends React.Component {
       groupSelect: false,
       languageSelect: false,
       skillsLoaded: false,
-      filter:
-        '&applyFilter=true&filter_name=ascending&filter_type=lexicographical',
+      filter: '&applyFilter=true&filter_name=descending&filter_type=rating',
       searchQuery: '',
     };
   }
@@ -179,7 +178,7 @@ export default class BrowseSkill extends React.Component {
     } else {
       url =
         urls.API_URL +
-        '/cms/getSkillList.json?group=All&applyFilter=true&filter_name=ascending&filter_type=lexicographical';
+        '/cms/getSkillList.json?group=All&applyFilter=true&filter_name=descending&filter_type=rating';
     }
 
     let self = this;


### PR DESCRIPTION
Fixes #[753

Changes: [Add here what changes were made in this issue and if possible provide links.]
* Show top rated skills by default on home page

Surge Deployment Link: https://pr-772-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot from 2018-06-18 00-15-01](https://user-images.githubusercontent.com/12656846/41511017-bec5a63c-728c-11e8-9a2b-c23730df4508.png)
