### PR TITLE
Display name of the user instead of email on the top bar

### DIFF
--- a/src/components/Auth/Login/Login.js
+++ b/src/components/Auth/Login/Login.js
@@ -90,12 +90,14 @@ class Login extends Component {
             let accessToken = response.access_token;
             let state = this.state;
             let time = response.valid_seconds;
+
             state.isFilled = true;
             state.accessToken = accessToken;
             state.success = true;
             state.msg = response.message;
             state.time = time;
             this.setState(state);
+
             this.handleOnSubmit(email, accessToken, time);
             let msg = 'You are logged in';
             state.msg = msg;

--- a/src/components/Auth/Logout.react.js
+++ b/src/components/Auth/Logout.react.js
@@ -19,6 +19,7 @@ class Logout extends Component {
     deleteCookie('serverUrl');
     deleteCookie('email');
     deleteCookie('showAdmin');
+    deleteCookie('username');
     this.props.history.push('/');
     window.location.reload();
   }

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -94,6 +94,24 @@ class StaticAppBar extends Component {
       },
     });
 
+    $.ajax({
+      url:
+        urls.API_URL +
+        '/aaa/listUserSettings.json?access_token=' +
+        cookies.get('loggedIn'),
+      jsonpCallback: 'pc',
+      dataType: 'jsonp',
+      jsonp: 'callback',
+      crossDomain: true,
+      success: function(data) {
+        let userName = data.settings.userName;
+        cookies.set('username', userName);
+      },
+      error: function(errorThrown) {
+        console.log(errorThrown);
+      },
+    });
+
     var didScroll;
     var lastScrollTop = 0;
     var delta = 5;
@@ -226,7 +244,7 @@ class StaticAppBar extends Component {
                 verticalAlign: 'super',
               }}
             >
-              {cookies.get('emailId')}
+              {cookies.get('username')}
             </label>
           ) : (
             <label />


### PR DESCRIPTION
Fixes #732

Changes: Now the name of the user is displayed on the top bar instead of the email. This is in consistency with https://github.com/fossasia/chat.susi.ai/pull/1350.

Surge Deployment Link: https://pr-778-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot from 2018-06-18 14-06-58](https://user-images.githubusercontent.com/31135861/41526539-2c65e696-7302-11e8-8fb9-cfcf1ef1388b.png)
