### PR TITLE
Synchronise Conversation View with Code View

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -13,9 +13,12 @@ class Build extends Component {
         name: 'Welcome!',
         children: [],
       },
+      ConversationData: {
+        userQueries: [],
+        botResponses: [],
+      },
       skillCode:
         '::name <Skill_name>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query',
-      skills: [],
     };
   }
 
@@ -24,17 +27,22 @@ class Build extends Component {
   };
 
   componentDidMount() {
-    this.generateTreeData();
+    this.generateSkillData();
   }
 
   onSkillChange = skillCode => {
     this.setState({ skillCode });
-    this.generateTreeData();
+    this.generateSkillData();
   };
-  generateTreeData = () => {
+
+  generateSkillData = () => {
     let treeData_new = {
       name: 'Welcome!',
       children: [],
+    };
+    var conversationData_new = {
+      userQueries: [],
+      botResponses: [],
     };
     let tree_children = [];
     var lines = this.state.skillCode.split('\n');
@@ -61,11 +69,10 @@ class Build extends Component {
             !line.startsWith('!') &&
             !line.startsWith('#')
           ) {
-            bot_response = lines[i];
+            bot_response = line;
             break;
           }
         }
-
         let obj = {
           user_query,
           bot_response,
@@ -81,6 +88,7 @@ class Build extends Component {
       let bot_responses = [];
       if (line_bot) {
         let responses_bot = line_bot.trim().split('|');
+        conversationData_new.botResponses.push(responses_bot);
         for (let response of responses_bot) {
           let obj = {
             name: response.trim(),
@@ -90,6 +98,7 @@ class Build extends Component {
         }
       }
       let queries = line_user.trim().split('|');
+      conversationData_new.userQueries.push(queries);
       for (let query of queries) {
         let obj = {
           name: query.trim(),
@@ -100,7 +109,9 @@ class Build extends Component {
       }
     }
     treeData_new.children = tree_children;
+    this.setState({ ConversationData: conversationData_new });
     this.setState({ treeData: treeData_new });
+    console.log(conversationData_new);
   };
   render() {
     return (
@@ -128,7 +139,9 @@ class Build extends Component {
               />
             ) : null}
             {this.state.value === 2 ? (
-              <ConversationView treeData={this.state.treeData} />
+              <ConversationView
+                ConversationData={this.state.ConversationData}
+              />
             ) : null}
             {this.state.value === 3 ? (
               <TreeView treeData={this.state.treeData} />

--- a/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.css
+++ b/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.css
@@ -6,6 +6,7 @@
     max-width: 60%;
     min-width: 60px;
     margin-right: 10px;
+    margin-left: auto;
     margin-bottom: 15px;
     border-radius: 12px;
 }

--- a/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.js
+++ b/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import colors from '../../../../Utils/colors';
 import { Paper } from 'material-ui';
+import PropTypes from 'prop-types';
 import RaisedButton from 'material-ui/RaisedButton';
 import Snackbar from 'material-ui/Snackbar';
 import Person from 'material-ui/svg-icons/social/person';
@@ -8,7 +9,8 @@ import Delete from 'material-ui/svg-icons/action/delete';
 import './ConversationView.css';
 
 let conversation = [],
-  indexConv = 0;
+  indexConv = 0,
+  conversation_from_code = [];
 
 class ConversationView extends Component {
   constructor(props) {
@@ -25,6 +27,11 @@ class ConversationView extends Component {
     this.handleDelete = this.handleDelete.bind(this);
   }
 
+  componentDidMount() {
+    conversation_from_code = [];
+    this.generateConversation();
+  }
+
   handleChange(event) {
     this.setState({
       value: event.target.value,
@@ -36,6 +43,13 @@ class ConversationView extends Component {
     this.setState({
       openSnackbar: true,
       msgSnackbar: 'Text successfully deleted!',
+    });
+  }
+
+  handleLoad(event) {
+    this.setState({
+      openSnackbar: true,
+      msgSnackbar: 'Conversation Loaded Successfully!',
     });
   }
 
@@ -51,6 +65,44 @@ class ConversationView extends Component {
       event.preventDefault();
     }
   }
+
+  generateConversation = () => {
+    let conversation_data = this.props.ConversationData;
+    let user_queries = conversation_data.userQueries;
+    let bot_responses = conversation_data.botResponses;
+    for (let i = 0; i < user_queries.length; i++) {
+      let user_query = user_queries[i];
+      for (let query of user_query) {
+        if (query !== '') {
+          conversation_from_code.push(
+            <div style={{ display: 'flex', flexDirection: 'row' }}>
+              <div className="user-text-box">{query}</div>
+              <Person style={{ height: '40px' }} />
+            </div>,
+          );
+        }
+      }
+      let bot_response = bot_responses[i];
+      if (bot_response) {
+        for (let response of bot_response) {
+          if (response !== '') {
+            conversation_from_code.push(
+              <div style={{ display: 'flex', flexDirection: 'row' }}>
+                <img
+                  src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIISURBVFhH7di/S5VRHMfxa0RG0A+kKCGkIkhHazEKatAGB0EhCIeQhgajbBBqqSmJgiASKxpqkNZwcBBdRHELyoZESpD8A5QITNT0/TG/8CXO/eG9Hp8LPR94Dc+X5+F8eTj3nPPczP+U43iHGxtXZZinWMMyKlUot7yEGpSDKpRDDuAORvAL1uAUXuEcEksH5mFNZfMBR7FjqcALhJrJ5gfOYEfyAKEm8lGTVYgazakVhBooxHtEzQBssFk046GreZNoQq+rraIOUXII/u31wPITVje3oOyHrz9ClLTAD/Qdl9Dtat5HnMcTV5MJREkn/EDFmkOU3EdoQHmDWpzapLm5gNC9qkdJA+5lEVo+WhG69y7SlEVOQyeUL5iJ4BuGcB27sKVcxW+EJnkMw9iHgnIWS7CHtWNk+0WWYhqL7rofBUXHI3uoCzq9jLvadrmIk1Cjuv4DLVV5YwdPv+LHalDxO9RtFXLF75uvVdhMzAZPwGp+fw9G3xJ2s37BlpgN1sBqj1XIlbRBp6gG98DWPz8fYjaol6KDrGraq/OmDc9xeOPqb8bw7wClugBLO56h6O/pPoQGKZY2Av8CSs4xfEZosK1Sczex7dmNejSW4DKOII1lL+yYH6KpkWi0VITmmRlEotH/LaHGjP7QTDQ6CX9CqDm5gsRTjbf4CjvOj+Ia0qTJnUxmHfGs+A6k/UOLAAAAAElFTkSuQmCC"
+                  alt="bot icon"
+                  style={styles.botIcon}
+                />
+                <div className="bot-text-box">{response}</div>
+              </div>,
+            );
+          }
+        }
+      }
+    }
+    console.log(conversation_from_code);
+    this.handleLoad();
+  };
 
   handleTexts = (type, i) => {
     switch (type) {
@@ -98,7 +150,7 @@ class ConversationView extends Component {
     return (
       <div style={{ padding: '10px 10px 20px 10px' }}>
         <Paper id="message-container" style={styles.paperStyle} zDepth={1}>
-          {conversation}
+          {conversation_from_code}
         </Paper>
         <form onSubmit={this.handleSubmit} style={{ marginTop: '15px' }}>
           <label>
@@ -189,5 +241,7 @@ const styles = {
     cursor: 'pointer',
   },
 };
-
+ConversationView.propTypes = {
+  ConversationData: PropTypes.object,
+};
 export default ConversationView;


### PR DESCRIPTION
Partially solves issue #745

Changes:  Synchronised Conversation View with Code View.
Currently this works for only text type skills separated by `|`. Try writing a skill in code view, it will inflict changes in conversation view.
NOTE: This doesn't work the other way around for now. This will be done in upcoming PRs.

Next steps:
- Improve the UI. Currently it's a bit difficult to understand what is going on in conversation view.
- Make the conversation boxes clickable to show particular conversation.
- Allow changes in conversation view.

Surge Deployment Link: https://pr-779-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![jun-18-2018 18-28-52](https://user-images.githubusercontent.com/31174685/41537502-4f3770bc-7326-11e8-9bec-819464eacbde.gif)
