### PR TITLE
Add tooltip to tree view and make botbuilder page responsive

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/BuildViews/TreeView.js
+++ b/src/components/BotBuilder/BotBuilderPages/BuildViews/TreeView.js
@@ -2,25 +2,21 @@ import React, { Component } from 'react';
 import OrgChart from 'react-orgchart';
 import PropTypes from 'prop-types';
 import Person from 'material-ui/svg-icons/social/person';
+import ReactTooltip from 'react-tooltip';
 import 'react-orgchart/index.css';
 import './TreeView.css';
 
 class TreeView extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      value: 1,
-    };
-  }
-
-  handleChange = (event, index, value) => {
-    this.setState({ value });
+  getNodeText = text => {
+    if (text.indexOf(' ') > 0) {
+      return text.substr(0, text.indexOf(' ')) + '...';
+    }
+    return text;
   };
-  componentDidMount() {}
   render() {
     const MyNodeComponent = ({ node }) => {
       return (
-        <div className="initechNode">
+        <div className="initechNode" data-tip={node.name}>
           {node.type === 'bot' && (
             <img
               src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAoCAYAAACM/rhtAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAIISURBVFhH7di/S5VRHMfxa0RG0A+kKCGkIkhHazEKatAGB0EhCIeQhgajbBBqqSmJgiASKxpqkNZwcBBdRHELyoZESpD8A5QITNT0/TG/8CXO/eG9Hp8LPR94Dc+X5+F8eTj3nPPczP+U43iHGxtXZZinWMMyKlUot7yEGpSDKpRDDuAORvAL1uAUXuEcEksH5mFNZfMBR7FjqcALhJrJ5gfOYEfyAKEm8lGTVYgazakVhBooxHtEzQBssFk046GreZNoQq+rraIOUXII/u31wPITVje3oOyHrz9ClLTAD/Qdl9Dtat5HnMcTV5MJREkn/EDFmkOU3EdoQHmDWpzapLm5gNC9qkdJA+5lEVo+WhG69y7SlEVOQyeUL5iJ4BuGcB27sKVcxW+EJnkMw9iHgnIWS7CHtWNk+0WWYhqL7rofBUXHI3uoCzq9jLvadrmIk1Cjuv4DLVV5YwdPv+LHalDxO9RtFXLF75uvVdhMzAZPwGp+fw9G3xJ2s37BlpgN1sBqj1XIlbRBp6gG98DWPz8fYjaol6KDrGraq/OmDc9xeOPqb8bw7wClugBLO56h6O/pPoQGKZY2Av8CSs4xfEZosK1Sczex7dmNejSW4DKOII1lL+yYH6KpkWi0VITmmRlEotH/LaHGjP7QTDQ6CX9CqDm5gsRTjbf4CjvOj+Ia0qTJnUxmHfGs+A6k/UOLAAAAAElFTkSuQmCC"
@@ -28,14 +24,15 @@ class TreeView extends Component {
               style={styles.botIcon}
             />
           )}
-          {node.type === 'user' && <Person style={styles.icon} />}&nbsp;{
-            node.name
-          }
+          {node.type === 'user' && <Person style={styles.icon} />}&nbsp;{this.getNodeText(
+            node.name,
+          )}
         </div>
       );
     };
     return (
       <div>
+        <ReactTooltip effect="solid" place="bottom" />
         <div>
           <OrgChart
             tree={this.props.treeData}

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import RaisedButton from 'material-ui/RaisedButton';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import { Step, Stepper, StepButton } from 'material-ui/Stepper';
+import { Grid, Col, Row } from 'react-flexbox-grid';
 import colors from '../../Utils/colors';
 import Build from './BotBuilderPages/Build';
 import Design from './BotBuilderPages/Design';
@@ -89,78 +90,83 @@ class BotWizard extends React.Component {
             className="botBuilder-page-card"
             zDepth={1}
           >
-            <div style={{ display: 'flex', flexDirection: 'row' }}>
-              <div style={{ width: '100%', maxWidth: '100%', margin: 'auto' }}>
-                <Stepper activeStep={stepIndex} linear={false}>
-                  <Step>
-                    <StepButton onClick={() => this.setStep(0)}>
-                      Build
-                    </StepButton>
-                  </Step>
-                  <Step>
-                    <StepButton onClick={() => this.setStep(1)}>
-                      Design
-                    </StepButton>
-                  </Step>
-                  <Step>
-                    <StepButton onClick={() => this.setStep(2)}>
-                      Configure
-                    </StepButton>
-                  </Step>
-                  <Step>
-                    <StepButton onClick={() => this.setStep(3)}>
-                      Deploy
-                    </StepButton>
-                  </Step>
-                </Stepper>
-                <div style={contentStyle}>
-                  <div>{this.getStepContent(stepIndex)}</div>
-                  <div style={{ marginTop: '20px' }}>
-                    <RaisedButton
-                      label="Back"
-                      disabled={stepIndex === 0}
-                      backgroundColor={colors.header}
-                      labelColor="#fff"
-                      onTouchTap={this.handlePrev}
-                      style={{ marginRight: 12 }}
-                    />
-                    {stepIndex < 3 ? (
+            <Grid fluid>
+              <Row>
+                <Col xs={12} md={8}>
+                  <Stepper activeStep={stepIndex} linear={false}>
+                    <Step>
+                      <StepButton onClick={() => this.setStep(0)}>
+                        Build
+                      </StepButton>
+                    </Step>
+                    <Step>
+                      <StepButton onClick={() => this.setStep(1)}>
+                        Design
+                      </StepButton>
+                    </Step>
+                    <Step>
+                      <StepButton onClick={() => this.setStep(2)}>
+                        Configure
+                      </StepButton>
+                    </Step>
+                    <Step>
+                      <StepButton onClick={() => this.setStep(3)}>
+                        Deploy
+                      </StepButton>
+                    </Step>
+                  </Stepper>
+                  <div style={contentStyle}>
+                    <div>{this.getStepContent(stepIndex)}</div>
+                    <div style={{ marginTop: '20px' }}>
                       <RaisedButton
-                        label={stepIndex === 2 ? 'Finish' : 'Next'}
+                        label="Back"
+                        disabled={stepIndex === 0}
                         backgroundColor={colors.header}
                         labelColor="#fff"
-                        onTouchTap={this.handleNext}
+                        onTouchTap={this.handlePrev}
+                        style={{ marginRight: 12 }}
                       />
-                    ) : (
-                      <p
-                        style={{
-                          padding: '20px 0px 0px 0px',
-                          fontFamily: 'sans-serif',
-                          fontSize: '14px',
-                        }}
-                      >
-                        You&apos;re all done. Thanks for using SUSI Bot.
-                      </p>
-                    )}
+                      {stepIndex < 3 ? (
+                        <RaisedButton
+                          label={stepIndex === 2 ? 'Finish' : 'Next'}
+                          backgroundColor={colors.header}
+                          labelColor="#fff"
+                          onTouchTap={this.handleNext}
+                        />
+                      ) : (
+                        <p
+                          style={{
+                            padding: '20px 0px 0px 0px',
+                            fontFamily: 'sans-serif',
+                            fontSize: '14px',
+                          }}
+                        >
+                          You&apos;re all done. Thanks for using SUSI Bot.
+                        </p>
+                      )}
+                    </div>
                   </div>
-                </div>
-              </div>
-              <div style={{ padding: '20px 0 0 40px' }}>
-                <br className="display-mobile-only" />
-                <h2 className="center">Preview</h2>
-                <br />
-                <div style={{ position: 'relative', overflow: 'hidden' }}>
-                  <iframe
-                    title="botPreview"
-                    name="frame-1"
-                    id="frame-1"
-                    src={locationBot}
-                    height="600"
-                    width="460"
-                  />
-                </div>
-              </div>
-            </div>
+                </Col>
+
+                <Col xs={12} md={4}>
+                  <div style={{ padding: '20px 0 0 40px' }}>
+                    <br className="display-mobile-only" />
+                    <h2 className="center">Preview</h2>
+                    <br />
+                    <div style={{ position: 'relative', overflow: 'hidden' }}>
+                      <iframe
+                        title="botPreview"
+                        name="frame-1"
+                        id="frame-1"
+                        src={locationBot}
+                        height="600"
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                </Col>
+              </Row>
+            </Grid>
           </Paper>
         </div>
       </div>


### PR DESCRIPTION
Fixes partially #695 

Changes: 
- Add tooltip to tree nodes. The first word of the response is shown in the node and the full sentence is visible on the tooltip when hovered over the node
- Make botbuilder page responsive by introducing `Row` and `Col`.

Surge Deployment Link: https://pr-782-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![tree view responsive](https://user-images.githubusercontent.com/17807257/41560272-38788d0a-7364-11e8-8438-79be4755128b.png)
