### PR TITLE
Fixes #788: Remove jsonpCallback from AJAX calls

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -35,7 +35,6 @@ class Admin extends Component {
     $.ajax({
       url: url,
       dataType: 'jsonp',
-      jsonpCallback: 'pyfw',
       jsonp: 'callback',
       crossDomain: true,
       success: function(response) {

--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -85,7 +85,6 @@ export default class ListUser extends Component {
     $.ajax({
       url: url,
       dataType: 'jsonp',
-      jsonpCallback: 'py',
       jsonp: 'callback',
       crossDomain: true,
       success: function(response) {
@@ -98,7 +97,6 @@ export default class ListUser extends Component {
           $.ajax({
             url: getPagesUrl,
             dataType: 'jsonp',
-            jsonpCallback: 'pvsdu',
             jsonp: 'callback',
             crossDomain: true,
             success: function(data) {
@@ -145,7 +143,6 @@ export default class ListUser extends Component {
     $.ajax({
       url: url,
       dataType: 'jsonp',
-      jsonpCallback: 'pvsdu',
       jsonp: 'callback',
       crossDomain: true,
       success: function(response) {

--- a/src/components/Auth/Login/Login.js
+++ b/src/components/Auth/Login/Login.js
@@ -80,7 +80,6 @@ class Login extends Component {
       $.ajax({
         url: loginEndPoint,
         dataType: 'jsonp',
-        jsonpCallback: 'p',
         jsonp: 'callback',
         crossDomain: true,
         success: function(response) {

--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -145,7 +145,6 @@ class Design extends React.Component {
     this.setState({ saving: true });
     $.ajax({
       url: url,
-      jsonpCallback: 'pa',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,
@@ -175,7 +174,6 @@ class Design extends React.Component {
       cookies.get('loggedIn');
     $.ajax({
       url: url,
-      jsonpCallback: 'p',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,
@@ -317,7 +315,6 @@ class Design extends React.Component {
     this.setState({ resetting: true });
     $.ajax({
       url: url,
-      jsonpCallback: 'pa',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,

--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -97,7 +97,6 @@ export default class BrowseSkill extends React.Component {
     if (this.state.groups.length === 0) {
       $.ajax({
         url: urls.API_URL + '/cms/getGroups.json',
-        jsonpCallback: 'pb',
         dataType: 'jsonp',
         jsonp: 'callback',
         crossDomain: true,
@@ -185,7 +184,6 @@ export default class BrowseSkill extends React.Component {
     let self = this;
     $.ajax({
       url: url,
-      jsonpCallback: 'pxcd',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -118,7 +118,6 @@ export default class CreateSkill extends React.Component {
     if (this.state.groups.length === 0) {
       $.ajax({
         url: urls.API_URL + '/cms/getGroups.json',
-        jsonpCallback: 'pa',
         dataType: 'jsonp',
         jsonp: 'callback',
         crossDomain: true,

--- a/src/components/Dashboard/MyRatings.js
+++ b/src/components/Dashboard/MyRatings.js
@@ -76,7 +76,6 @@ class MyRatings extends Component {
     let ratingsData = [];
     $.ajax({
       url: url,
-      jsonpCallback: 'pxcd',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,

--- a/src/components/Dashboard/MySkills.js
+++ b/src/components/Dashboard/MySkills.js
@@ -50,7 +50,6 @@ class MySkills extends Component {
     let skillsData = [];
     $.ajax({
       url: url,
-      jsonpCallback: 'pxcd',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,

--- a/src/components/SkillEditor/SkillEditor.js
+++ b/src/components/SkillEditor/SkillEditor.js
@@ -123,7 +123,6 @@ class SkillEditor extends Component {
     if (groups.length === 0) {
       $.ajax({
         url: urls.API_URL + '/cms/getGroups.json',
-        jsonpCallback: 'pa',
         dataType: 'jsonp',
         jsonp: 'callback',
         crossDomain: true,
@@ -205,7 +204,6 @@ class SkillEditor extends Component {
         this.state.commitId;
       $.ajax({
         url: skillAtCommitIDUrl,
-        jsonpCallback: 'p',
         dataType: 'jsonp',
         jsonp: 'callback',
         crossDomain: true,
@@ -234,7 +232,6 @@ class SkillEditor extends Component {
       });
       $.ajax({
         url: url,
-        jsonpCallback: 'pd',
         dataType: 'jsonp',
         jsonp: 'callback',
         crossDomain: true,
@@ -273,7 +270,6 @@ class SkillEditor extends Component {
     });
     $.ajax({
       url: url,
-      jsonpCallback: 'pd',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,
@@ -287,7 +283,6 @@ class SkillEditor extends Component {
  */ $.ajax(
       {
         url: url,
-        jsonpCallback: 'pcc',
         dataType: 'jsonp',
         jsonp: 'callback',
         crossDomain: true,
@@ -340,7 +335,6 @@ class SkillEditor extends Component {
     if (groups.length === 0) {
       $.ajax({
         url: urls.API_URL + '/aaa/getGroups.json',
-        jsonpCallback: 'pb',
         dataType: 'jsonp',
         jsonp: 'callback',
         crossDomain: true,
@@ -462,7 +456,6 @@ class SkillEditor extends Component {
         this.state.oldGroupValue +
         '&language=' +
         this.state.oldLanguageValue,
-      jsonpCallback: 'pa',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,

--- a/src/components/SkillHistory/SkillHistory.js
+++ b/src/components/SkillHistory/SkillHistory.js
@@ -87,7 +87,6 @@ class SkillHistory extends Component {
     let self = this;
     $.ajax({
       url: commitHistoryURL,
-      jsonpCallback: 'pv',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,
@@ -132,7 +131,6 @@ class SkillHistory extends Component {
       // console.log(url1);
       $.ajax({
         url: url1,
-        jsonpCallback: 'pc',
         dataType: 'jsonp',
         jsonp: 'callback',
         crossDomain: true,
@@ -141,7 +139,6 @@ class SkillHistory extends Component {
           // console.log(url2);
           $.ajax({
             url: url2,
-            jsonpCallback: 'pd',
             dataType: 'jsonp',
             jsonp: 'callback',
             crossDomain: true,

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -177,7 +177,6 @@ class SkillListing extends Component {
       let self = this;
       $.ajax({
         url: url,
-        jsonpCallback: 'pc',
         dataType: 'jsonp',
         jsonp: 'callback',
         crossDomain: true,
@@ -372,7 +371,6 @@ class SkillListing extends Component {
     let self = this;
     $.ajax({
       url: changeRatingUrl,
-      jsonpCallback: 'pc',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,

--- a/src/components/SkillRollBack/SkillRollBack.js
+++ b/src/components/SkillRollBack/SkillRollBack.js
@@ -76,7 +76,6 @@ class SkillRollBack extends Component {
     // console.log(url1);
     $.ajax({
       url: url1,
-      jsonpCallback: 'pc',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,
@@ -85,7 +84,6 @@ class SkillRollBack extends Component {
         // console.log(url2);
         $.ajax({
           url: url2,
-          jsonpCallback: 'pd',
           dataType: 'jsonp',
           jsonp: 'callback',
           crossDomain: true,

--- a/src/components/SkillVersion/SkillVersion.js
+++ b/src/components/SkillVersion/SkillVersion.js
@@ -60,7 +60,6 @@ class SkillVersion extends Component {
     let self = this;
     $.ajax({
       url: commitHistoryURL,
-      jsonpCallback: 'pv',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -78,7 +78,6 @@ class StaticAppBar extends Component {
     $.ajax({
       url: url,
       dataType: 'jsonp',
-      jsonpCallback: 'pfns',
       jsonp: 'callback',
       crossDomain: true,
       success: function(newResponse) {
@@ -99,7 +98,6 @@ class StaticAppBar extends Component {
         urls.API_URL +
         '/aaa/listUserSettings.json?access_token=' +
         cookies.get('loggedIn'),
-      jsonpCallback: 'pc',
       dataType: 'jsonp',
       jsonp: 'callback',
       crossDomain: true,


### PR DESCRIPTION
Fixes #788 

Changes: [Add here what changes were made in this issue and if possible provide links.]
Remove jsonpCallback from AJAX calls and used jsonpCallback that is assigned automatically

Surge Deployment Link: https://pr-790-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
NA