### PR TITLE
Implemented skill sorting by usage count

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -429,6 +429,26 @@ export default class BrowseSkill extends React.Component {
                 primaryText={'Feedback Count'}
                 label={'Feedback Count'}
               />
+              <MenuItem
+                value={
+                  '&applyFilter=true&filter_name=descending&filter_type=usage&duration=7'
+                }
+                key={
+                  '&applyFilter=true&filter_name=descending&filter_type=usage&duration=7'
+                }
+                primaryText={'This Week Usage'}
+                label={'This Week Usage'}
+              />
+              <MenuItem
+                value={
+                  '&applyFilter=true&filter_name=descending&filter_type=usage&duration=30'
+                }
+                key={
+                  '&applyFilter=true&filter_name=descending&filter_type=usage&duration=30'
+                }
+                primaryText={'This Month Usage'}
+                label={'This Month Usage'}
+              />
             </SelectField>
 
             <div style={styles.newSkillBtn}>


### PR DESCRIPTION
Fixes 
Implement skill sorting by their usage count. #769

Changes: 
Added "This Week Usage" and "This Month Usage" in the drop down menu to sort the skills in decreasing order of their usage count.
Server side PR : https://github.com/fossasia/susi_server/pull/849

Surge Deployment Link: http://susi--cms.surge.sh/
NOTE : https://github.com/fossasia/susi_server/pull/849

Screenshots for the change:
![image](https://user-images.githubusercontent.com/10573038/41587064-eade5d82-73cb-11e8-96ab-766098c2881b.png)

(Please also suggest if it can be implemented in a better way)
