### PR TITLE
Add My Bots section to Botbuilder, option to add name of bot and save it

### DIFF
--- a/src/components/BotBuilder/BotBuilder.js
+++ b/src/components/BotBuilder/BotBuilder.js
@@ -4,8 +4,9 @@ import RaisedButton from 'material-ui/RaisedButton';
 import { Grid, Col, Row } from 'react-flexbox-grid';
 import PropTypes from 'prop-types';
 import { Card } from 'material-ui/Card';
-import { Paper } from 'material-ui';
+import ReactTooltip from 'react-tooltip';
 import Add from 'material-ui/svg-icons/content/add';
+import { FloatingActionButton, Paper } from 'material-ui';
 import colors from '../../Utils/colors';
 import './BotBuilder.css';
 import { Link } from 'react-router-dom';
@@ -73,23 +74,54 @@ class BotBuilder extends React.Component {
             className="botBuilder-page-card"
             zDepth={1}
           >
+            <div style={{ display: 'flex', flexDirection: 'row' }}>
+              <h1 style={{ padding: '5px 0 0 15px' }}>My bots</h1>
+              <div style={{ marginRight: '0', marginLeft: 'auto' }}>
+                <div style={styles.newBotBtn}>
+                  <Link to="/botbuilder/botwizard">
+                    <FloatingActionButton
+                      data-tip="Create a new bot"
+                      backgroundColor={colors.fabButton}
+                      style={styles.select}
+                    >
+                      <Add />
+                    </FloatingActionButton>
+                    <ReactTooltip effect="solid" place="bottom" />
+                  </Link>
+                </div>
+              </div>
+            </div>
             <Grid>
               <Row>
                 <Col xs={12} md={12}>
-                  <h1>My bots</h1>
                   <div className="bot-template-wrap">
-                    <Link to="/botbuilder/botwizard">
-                      <Card className="bot-template-card">
-                        <RaisedButton
-                          label={'Create new'}
-                          labelPosition="before"
-                          icon={<Add />}
-                          labelStyle={{ verticalAlign: 'middle' }}
-                          backgroundColor={colors.header}
-                          labelColor="#fff"
-                        />
-                      </Card>
-                    </Link>
+                    <Card className="bot-template-card">
+                      <RaisedButton
+                        label={'Sample Bot 1'}
+                        labelPosition="before"
+                        labelStyle={{ verticalAlign: 'middle' }}
+                        backgroundColor={colors.header}
+                        labelColor="#fff"
+                      />
+                    </Card>
+                    <Card className="bot-template-card">
+                      <RaisedButton
+                        label={'Sample Bot 2'}
+                        labelPosition="before"
+                        labelStyle={{ verticalAlign: 'middle' }}
+                        backgroundColor={colors.header}
+                        labelColor="#fff"
+                      />
+                    </Card>
+                    <Card className="bot-template-card">
+                      <RaisedButton
+                        label={'Sample Bot 3'}
+                        labelPosition="before"
+                        labelStyle={{ verticalAlign: 'middle' }}
+                        backgroundColor={colors.header}
+                        labelColor="#fff"
+                      />
+                    </Card>
                   </div>
                 </Col>
               </Row>
@@ -112,6 +144,7 @@ const styles = {
   paperStyle: {
     width: '100%',
     marginTop: '20px',
+    overflow: 'overlay',
   },
   tabStyle: {
     color: 'rgb(91, 91, 91)',
@@ -127,6 +160,9 @@ const styles = {
     marginBottom: '100px',
     fontSize: '50px',
     marginTop: '300px',
+  },
+  newBotBtn: {
+    padding: '10px 0px 10px 10px',
   },
 };
 

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import RaisedButton from 'material-ui/RaisedButton';
+import TextField from 'material-ui/TextField';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import { Step, Stepper, StepButton } from 'material-ui/Stepper';
 import { Grid, Col, Row } from 'react-flexbox-grid';
@@ -9,6 +10,7 @@ import PropTypes from 'prop-types';
 import Design from './BotBuilderPages/Design';
 import Configure from './BotBuilderPages/Configure';
 import Deploy from './BotBuilderPages/Deploy';
+import Snackbar from 'material-ui/Snackbar';
 import { Paper } from 'material-ui';
 import Cookies from 'universal-cookie';
 
@@ -30,8 +32,19 @@ class BotWizard extends React.Component {
       stepIndex: 0,
       startCode,
       themeSettingsString: '{}',
+      botName: '',
+      openSnackbar: false,
+      msgSnackbar: '',
     };
+    this.handleChange = this.handleChange.bind(this);
   }
+
+  handleChange(event) {
+    this.setState({
+      botName: event.target.value,
+    });
+  }
+
   getQueryStringValue = key => {
     return decodeURIComponent(
       window.location.search.replace(
@@ -79,9 +92,17 @@ class BotWizard extends React.Component {
     }
   }
 
+  noName() {
+    this.setState({
+      openSnackbar: true,
+      msgSnackbar: 'Please enter name of the bot.',
+    });
+  }
+
   setStep = stepIndex => {
     this.setState({ stepIndex });
   };
+
   render() {
     if (!cookies.get('loggedIn')) {
       return (
@@ -115,63 +136,99 @@ class BotWizard extends React.Component {
             <Grid fluid>
               <Row>
                 <Col xs={12} md={8}>
-                  <Stepper activeStep={stepIndex} linear={false}>
-                    <Step>
-                      <StepButton onClick={() => this.setStep(0)}>
-                        Build
-                      </StepButton>
-                    </Step>
-                    <Step>
-                      <StepButton onClick={() => this.setStep(1)}>
-                        Design
-                      </StepButton>
-                    </Step>
-                    <Step>
-                      <StepButton onClick={() => this.setStep(2)}>
-                        Configure
-                      </StepButton>
-                    </Step>
-                    <Step>
-                      <StepButton onClick={() => this.setStep(3)}>
-                        Deploy
-                      </StepButton>
-                    </Step>
-                  </Stepper>
-                  <div style={contentStyle}>
-                    <div>{this.getStepContent(stepIndex)}</div>
-                    <div style={{ marginTop: '20px' }}>
-                      <RaisedButton
-                        label="Back"
-                        disabled={stepIndex === 0}
-                        backgroundColor={colors.header}
-                        labelColor="#fff"
-                        onTouchTap={this.handlePrev}
-                        style={{ marginRight: 12 }}
-                      />
-                      {stepIndex < 3 ? (
-                        <RaisedButton
-                          label={stepIndex === 2 ? 'Finish' : 'Next'}
-                          backgroundColor={colors.header}
-                          labelColor="#fff"
-                          onTouchTap={this.handleNext}
-                        />
-                      ) : (
-                        <p
-                          style={{
-                            padding: '20px 0px 0px 0px',
-                            fontFamily: 'sans-serif',
-                            fontSize: '14px',
-                          }}
-                        >
-                          You&apos;re all done. Thanks for using SUSI Bot.
-                        </p>
-                      )}
+                  <div style={{ display: 'flex', flexDirection: 'row' }}>
+                    <TextField
+                      hintText="Enter name of the bot"
+                      floatingLabelText="Bot Name"
+                      onChange={this.handleChange}
+                      value={this.state.botName}
+                      style={{ paddingLeft: '20px' }}
+                    />
+                  </div>
+                  <div style={{ display: 'flex', flexDirection: 'row' }}>
+                    <div
+                      style={{
+                        width: '100%',
+                        maxWidth: '100%',
+                        margin: 'auto',
+                      }}
+                    >
+                      <Stepper activeStep={stepIndex} linear={false}>
+                        <Step>
+                          <StepButton onClick={() => this.setStep(0)}>
+                            Build
+                          </StepButton>
+                        </Step>
+                        <Step>
+                          <StepButton onClick={() => this.setStep(1)}>
+                            Design
+                          </StepButton>
+                        </Step>
+                        <Step>
+                          <StepButton onClick={() => this.setStep(2)}>
+                            Configure
+                          </StepButton>
+                        </Step>
+                        <Step>
+                          <StepButton onClick={() => this.setStep(3)}>
+                            Deploy
+                          </StepButton>
+                        </Step>
+                      </Stepper>
+                      <div style={contentStyle}>
+                        <div>{this.getStepContent(stepIndex)}</div>
+                        <div style={{ marginTop: '20px' }}>
+                          <RaisedButton
+                            label="Back"
+                            disabled={stepIndex === 0}
+                            backgroundColor={colors.header}
+                            labelColor="#fff"
+                            onTouchTap={this.handlePrev}
+                            style={{ marginRight: 12 }}
+                          />
+                          {stepIndex < 3 ? (
+                            <RaisedButton
+                              label={stepIndex === 2 ? 'Finish' : 'Next'}
+                              backgroundColor={colors.header}
+                              labelColor="#fff"
+                              onTouchTap={this.handleNext}
+                            />
+                          ) : (
+                            <p
+                              style={{
+                                padding: '20px 0px 0px 0px',
+                                fontFamily: 'sans-serif',
+                                fontSize: '14px',
+                              }}
+                            >
+                              You&apos;re all done. Thanks for using SUSI Bot.
+                            </p>
+                          )}
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </Col>
 
                 <Col xs={12} md={4}>
-                  <div style={{ padding: '20px 0 0 40px' }}>
+                  <div
+                    style={{
+                      padding: '20px 0 20px 0',
+                    }}
+                  >
+                    <RaisedButton
+                      label="Save and Deploy"
+                      backgroundColor={colors.header}
+                      labelColor="#fff"
+                      onClick={() =>
+                        this.state.botName !== ''
+                          ? this.setStep(3)
+                          : this.noName()
+                      }
+                      style={{ float: 'right' }}
+                    />
+                  </div>
+                  <div style={{ padding: '40px 0 0 40px' }}>
                     <br className="display-mobile-only" />
                     <h2 className="center">Preview</h2>
                     <br />
@@ -191,6 +248,14 @@ class BotWizard extends React.Component {
             </Grid>
           </Paper>
         </div>
+        <Snackbar
+          open={this.state.openSnackbar}
+          message={this.state.msgSnackbar}
+          autoHideDuration={2000}
+          onRequestClose={() => {
+            this.setState({ openSnackbar: false });
+          }}
+        />
       </div>
     );
   }


### PR DESCRIPTION
Partially fixes issue #744 
This solves most of the frontend part. Backend will be done in issue https://github.com/fossasia/susi_server/issues/859.

Changes: 
- Added "My Bots" Section to Botbuilder.
- Added field for name of the bot.
- Button to save and deploy the bot. This will work only if a name field isn't empty.

Surge Deployment Link: http://abounding-crush.surge.sh/

Screenshots for the change:

Botbuilder -
<img width="1225" alt="screen shot 2018-06-20 at 1 58 59 am" src="https://user-images.githubusercontent.com/31174685/41622975-f24ed354-742e-11e8-8e84-52aa89caea98.png">

Botwizard-
<img width="1181" alt="screen shot 2018-06-20 at 1 59 21 am" src="https://user-images.githubusercontent.com/31174685/41622982-fc8341f2-742e-11e8-862d-d8c7133e7bfd.png">

Save doesn't work if field is empty-
![jun-20-2018 02-03-07](https://user-images.githubusercontent.com/31174685/41622986-fece5ac8-742e-11e8-94a7-db90f9c24b32.gif)

