### PR TITLE
Correct alignment of botwizard with preview

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -89,8 +89,14 @@ class BotWizard extends React.Component {
             className="botBuilder-page-card"
             zDepth={1}
           >
-            <div style={{ display: 'flex', flexDirection: 'row' }}>
-              <div style={{ width: '100%', maxWidth: '100%', margin: 'auto' }}>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'row',
+                alignItems: 'flex-start',
+              }}
+            >
+              <div style={{ width: '100%', maxWidth: '100%' }}>
                 <Stepper activeStep={stepIndex} linear={false}>
                   <Step>
                     <StepButton onClick={() => this.setStep(0)}>


### PR DESCRIPTION
Fixes #801 

Changes: Corrected alignment of botwizard with preview.

Surge Deployment Link: https://pr-803-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
<img width="1285" alt="screen shot 2018-06-20 at 12 17 17 pm" src="https://user-images.githubusercontent.com/31174685/41641742-ed07b956-7483-11e8-9e7a-323ccedb5f9c.png">

After:
<img width="969" alt="screen shot 2018-06-20 at 2 19 45 pm" src="https://user-images.githubusercontent.com/31174685/41648038-790f71ee-7495-11e8-94bd-f3fb418b3bdb.png">


Before:
<img width="1279" alt="screen shot 2018-06-20 at 12 17 24 pm" src="https://user-images.githubusercontent.com/31174685/41641743-ee5123b0-7483-11e8-93d4-73d459bf8d9c.png">

After:
<img width="960" alt="screen shot 2018-06-20 at 2 19 52 pm" src="https://user-images.githubusercontent.com/31174685/41648040-7b0237e8-7495-11e8-8047-407a696649c8.png">


