### PR TITLE
Display email of the user on top bar if name hasn't been saved yet

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -248,7 +248,10 @@ class StaticAppBar extends Component {
                 verticalAlign: 'super',
               }}
             >
-              {cookies.get('username')}
+              {cookies.get('username') === '' ||
+              cookies.get('username') === 'undefined'
+                ? cookies.get('emailId')
+                : cookies.get('username')}
             </label>
           ) : (
             <label />


### PR DESCRIPTION
Fixes #794 

Changes: Now user's email is displayed on the top bar if he hasn't saved his name yet.

Surge Deployment Link: https://pr-805-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot from 2018-06-20 15-47-35](https://user-images.githubusercontent.com/31135861/41652709-8106e5ce-74a1-11e8-98d3-2c9cf318899a.png)

