### PR TITLE
Fixes #811: Make the UI regular of Skill Listing Page

### DIFF
--- a/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.css
+++ b/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.css
@@ -1,0 +1,5 @@
+.country-usage-graph {
+    flex: 3;
+    margin: 16px 32px 16px 16px;
+    padding: 20px;
+}

--- a/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.js
+++ b/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.js
@@ -1,18 +1,16 @@
 // Packages
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Paper } from 'material-ui';
 import { GeoChart } from 'react-chartkick';
 
 class CountryWiseSkillUsageCard extends Component {
   render() {
     return (
-      <Paper className="margin-b-md margin-t-md">
-        <h1 className="title">Country Wise Skill Usage</h1>
-        <div className="skill-usage-graph">
+      <div>
+        <div className="country-usage-graph">
           <GeoChart data={this.props.country_wise_skill_usage} />
         </div>
-      </Paper>
+      </div>
     );
   }
 }

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -10,7 +10,6 @@ import AuthorSkills from '../AuthorSkills/AuthorSkills';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import SkillUsageCard from '../SkillUsageCard/SkillUsageCard';
 import SkillRatingCard from '../SkillRatingCard/SkillRatingCard';
-import CountryWiseSkillUsageCard from '../CountryWiseSkillUsageCard/CountryWiseSkillUsageCard';
 import SkillFeedbackCard from '../SkillFeedbackCard/SkillFeedbackCard';
 import { FloatingActionButton, Paper } from 'material-ui';
 import Divider from 'material-ui/Divider';
@@ -796,8 +795,6 @@ class SkillListing extends Component {
             <SkillUsageCard
               skill_usage={this.state.skill_usage}
               device_usage_data={this.state.device_usage_data}
-            />
-            <CountryWiseSkillUsageCard
               country_wise_skill_usage={this.state.country_wise_skill_usage}
             />
           </div>

--- a/src/components/SkillUsageCard/SkillUsage.css
+++ b/src/components/SkillUsageCard/SkillUsage.css
@@ -1,30 +1,21 @@
-.title {
-  font-weight: normal
+.sub-title {
+  font-weight: normal;
+  font-size: 24px;
+  margin: 16px;
 }
 
-.usage-section {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-wrap: wrap;
-    margin: 24px;
-}
-
-.skill-usage-chart {
-    flex: 3;
-    margin: 16px 32px 16px 16px;
+.time-chart {
+    margin: 16px 16px 16px 16px;
     padding: 20px;
 }
 
-.overall-usage div {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+.device-usage {
+    margin: 16px 16px 16px 16px;
+    padding: 8px 8px 32px 8px;
 }
 
 .total-hits {
-  display: flex;
-  flex-direction: column;
+  text-align: center;
   padding: 24px 48px 24px 48px;
 }
 
@@ -39,4 +30,10 @@
   display: flex;
   justify-content: center;
   margin-bottom: 5px;
+}
+
+.pie-chart {
+  display: flex;
+  justify-content: center;
+  align-content: center;
 }

--- a/src/components/SkillUsageCard/SkillUsageCard.js
+++ b/src/components/SkillUsageCard/SkillUsageCard.js
@@ -14,6 +14,7 @@ import {
   Cell,
 } from 'recharts';
 import { Paper } from 'material-ui';
+import CountryWiseSkillUsageCard from '../CountryWiseSkillUsageCard/CountryWiseSkillUsageCard';
 
 // Static assets
 import './SkillUsage.css';
@@ -64,9 +65,10 @@ class SkillUsageCard extends Component {
         <Paper className="margin-b-md margin-t-md">
           <h1 className="title">Skill Usage</h1>
           {totalSkillUsage > 0 ? (
-            <div className="usage-section">
-              <div className="overall-usage">
-                <div className="skill-usage-graph">
+            <div>
+              <div className="time-chart">
+                <div className="sub-title">Time wise Usage</div>
+                <div>
                   <LineChart
                     width={this.state.width}
                     height={300}
@@ -91,14 +93,14 @@ class SkillUsageCard extends Component {
                     />
                   </LineChart>
                 </div>
-                <div className="total-hits">
-                  <div className="large-text">{totalSkillUsage}</div>
-                  Hits this week
-                </div>
+              </div>
+              <div className="total-hits">
+                <div className="large-text">{totalSkillUsage}</div>
+                Hits this week
               </div>
               {this.props.device_usage_data !== [] ? (
                 <div className="device-usage">
-                  <h2 className="title">Device Usage</h2>
+                  <div className="sub-title">Device wise Usage</div>
                   <div className="pie-chart">
                     <PieChart width={600} height={350}>
                       <Pie
@@ -106,11 +108,11 @@ class SkillUsageCard extends Component {
                         activeShape={renderActiveShape}
                         data={this.props.device_usage_data}
                         cx={300}
-                        cy={200}
-                        innerRadius={50}
+                        cy={175}
+                        innerRadius={80}
                         nameKey="device_type"
                         dataKey="count"
-                        outerRadius={80}
+                        outerRadius={120}
                         fill="#8884d8"
                         onMouseEnter={this.onPieEnter}
                       >
@@ -134,6 +136,18 @@ class SkillUsageCard extends Component {
                       />
                     </PieChart>
                   </div>
+                </div>
+              ) : (
+                ''
+              )}
+              {this.props.country_wise_skill_usage !== [] ? (
+                <div className="device-usage">
+                  <div className="sub-title">Country wise Usage</div>
+                  <CountryWiseSkillUsageCard
+                    country_wise_skill_usage={
+                      this.props.country_wise_skill_usage
+                    }
+                  />
                 </div>
               ) : (
                 ''
@@ -240,6 +254,7 @@ renderActiveShape.propTypes = {
 SkillUsageCard.propTypes = {
   skill_usage: PropTypes.array,
   device_usage_data: PropTypes.array,
+  country_wise_skill_usage: PropTypes.array,
 };
 
 export default SkillUsageCard;


### PR DESCRIPTION
Fixes #811 

Changes: [Add here what changes were made in this issue and if possible provide links.]
* Make the UI regular of Skill Listing Page
* Showed all the Skill Usage metrics on a same card

Surge Deployment Link: https://pr-812-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot from 2018-06-21 03-00-50](https://user-images.githubusercontent.com/12656846/41685813-570d42dc-74ff-11e8-8599-f69e9aac7b60.png)
