### PR TITLE
Fixes #817: Remove sample data from the device usage pie chart

### DIFF
--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -302,12 +302,6 @@ class SkillListing extends Component {
   };
 
   saveDeviceUsageData = (device_usage_data = []) => {
-    // Sample data to test
-    device_usage_data = [
-      { device_type: 'Android', count: 2 },
-      { device_type: 'iOS', count: 1 },
-      { device_type: 'Web', count: 5 },
-    ];
     this.setState({
       device_usage_data,
     });

--- a/src/components/SkillUsageCard/SkillUsageCard.js
+++ b/src/components/SkillUsageCard/SkillUsageCard.js
@@ -231,7 +231,7 @@ const renderActiveShape = props => {
         textAnchor={textAnchor}
         fill="#999"
       >
-        {`(Rate ${(percent * 100).toFixed(2)}%)`}
+        {`(${(percent * 100).toFixed(2)}%)`}
       </text>
     </g>
   );


### PR DESCRIPTION
Fixes #817 

Changes: Remove sample data usage from device wise usage pie chart.

Surge Deployment Link: https://pr-832-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/41739904-258049ca-75b4-11e8-872e-1cab30b15556.png)
