### PR TITLE
Allow user to create only protected skills from bot wizard

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -9,7 +9,7 @@ class Build extends Component {
   constructor(props) {
     super(props);
     let skillCode =
-      '::name <Skill_name>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query';
+      '::name <bot_name>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query';
     if (this.props.code) {
       skillCode = this.props.code;
     }

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -243,6 +243,11 @@ export default class CreateSkill extends React.Component {
     let groups = this.state.groups;
     let code = this.state.code;
     code = '::author_email ' + cookies.get('emailId') + '\n' + code;
+    if (this.props.botBuilder) {
+      code = '::protected Yes\n' + code;
+    } else {
+      code = '::protected No\n' + code;
+    }
     if (!cookies.get('loggedIn')) {
       notification.open({
         message: 'Not logged In',


### PR DESCRIPTION
Fixes #793 

Changes: `protected` is set as `Yes` (`true`) in bot wizard and as `No` (`false`) in skill creator from main page.

Surge Deployment Link: https://pr-838-fossasia-susi-skill-cms.surge.sh
