### PR TITLE
Make Bot Name same as Skill Name in bot wizard

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import RaisedButton from 'material-ui/RaisedButton';
-import TextField from 'material-ui/TextField';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import { Step, Stepper, StepButton } from 'material-ui/Stepper';
 import { Grid, Col, Row } from 'react-flexbox-grid';
@@ -32,17 +31,9 @@ class BotWizard extends React.Component {
       stepIndex: 0,
       startCode,
       themeSettingsString: '{}',
-      botName: '',
       openSnackbar: false,
       msgSnackbar: '',
     };
-    this.handleChange = this.handleChange.bind(this);
-  }
-
-  handleChange(event) {
-    this.setState({
-      botName: event.target.value,
-    });
   }
 
   getQueryStringValue = key => {
@@ -92,21 +83,6 @@ class BotWizard extends React.Component {
     }
   }
 
-  checkName() {
-    if (this.state.botName === '') {
-      this.setState({
-        openSnackbar: true,
-        msgSnackbar: 'Please enter a name for your bot.',
-      });
-    } else {
-      this.setState({
-        openSnackbar: true,
-        msgSnackbar: this.state.botName + ' is successfully deployed.',
-      });
-      this.handleNext();
-    }
-  }
-
   setStep = stepIndex => {
     this.setState({ stepIndex });
   };
@@ -144,15 +120,6 @@ class BotWizard extends React.Component {
             <Grid fluid>
               <Row>
                 <Col xs={12} md={8}>
-                  <div style={{ display: 'flex', flexDirection: 'row' }}>
-                    <TextField
-                      hintText="Enter name of the bot"
-                      floatingLabelText="Bot Name"
-                      onChange={this.handleChange}
-                      value={this.state.botName}
-                      style={{ paddingLeft: '20px' }}
-                    />
-                  </div>
                   <div style={{ display: 'flex', flexDirection: 'row' }}>
                     <div
                       style={{
@@ -201,11 +168,7 @@ class BotWizard extends React.Component {
                               }
                               backgroundColor={colors.header}
                               labelColor="#fff"
-                              onTouchTap={() =>
-                                this.state.stepIndex === 2
-                                  ? this.checkName()
-                                  : this.handleNext()
-                              }
+                              onTouchTap={this.handleNext}
                             />
                           ) : (
                             <p

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -444,10 +444,12 @@ export default class CreateSkill extends React.Component {
                 </SelectField>
                 <TextField
                   disabled={this.state.expertSelect}
-                  floatingLabelText="Skill name"
+                  floatingLabelText={
+                    this.props.botBuilder ? 'Bot Name' : 'Skill Name'
+                  }
                   floatingLabelFixed={false}
                   value={this.state.expertValue}
-                  hintText="Skill name"
+                  hintText={this.props.botBuilder ? 'Bot Name' : 'Skill Name'}
                   style={{ marginLeft: 10, marginRight: 10 }}
                   onChange={this.handleExpertChange}
                 />


### PR DESCRIPTION
Fixes #824 

Changes: Made Bot Name same as Skill Name in bot wizard. Removed the previous field of bot name.

Surge Deployment Link: https://pr-839-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
<img width="664" alt="screen shot 2018-06-23 at 12 56 42 am" src="https://user-images.githubusercontent.com/31174685/41795436-5fc378d8-7680-11e8-89bf-908e5d919332.png">


