### PR TITLE
Make preview in botbuilder slide in and out

### DIFF
--- a/public/chat-style.css
+++ b/public/chat-style.css
@@ -87,7 +87,7 @@
 
 #susi-frame-container.susi-frame-container-active {
     display: block;
-    height: 70%;
+    height: 460px;
     width: 350px;
     -webkit-backface-visibility: hidden;
     -webkit-transform-style: preserve-3d;
@@ -104,7 +104,6 @@ screen and (max-width:450px) {
         left: 0;
         right: 0;
         top: 0;
-        bottom: 0;
         border-radius: 0;
         max-height: none
     }
@@ -324,9 +323,9 @@ screen and (max-width:450px) {
     background-size: 15px;
     background-repeat: no-repeat;
     background-position: 50%;
-    position: fixed;
-    bottom: calc(70% + 40px);
-    right: 35px;
+    position: absolute;
+    right: 15px;
+    top: 15px;
     width: 30px;
     height: 30px;
     background-color: #666;

--- a/public/susi-chatbot.js
+++ b/public/susi-chatbot.js
@@ -16,6 +16,7 @@ headTag.appendChild(link);
 var script_tag = document.getElementById("susi-bot-script");
 var access_token = script_tag.getAttribute("data-token");
 var theme_settings = script_tag.getAttribute("data-theme")?script_tag.getAttribute("data-theme"):null;
+var botWindow = script_tag.getAttribute("data-bot-type")?(script_tag.getAttribute("data-bot-type")==="botWindow"?true:false):false;
 
 // custom theme variables
 var botbuilderBackgroundBody = "#ffffff";
@@ -113,7 +114,8 @@ function enableBot() {
 		var msgNumber = 0;//stores the message number to set id
 
 		// Add dynamic html bot content(Widget style)
-		var mybot = '<div id="susi-frame-container" class="susi-frame-container-active" style="display: none;">'+
+		let frameStyle=botWindow?"height:460px;top: inherit;":"";
+		var mybot = '<div id="susi-frame-container" class="susi-frame-container-active" style="display: none;'+frameStyle+'">'+
 				'<div id="susi-frame-wrap">'+
 				'<div id="susi">'+
 				    '<div id="susi-container" class="susi-container susi-reset">'+
@@ -144,8 +146,8 @@ function enableBot() {
 				    '</div>'+
 				'</div>'+
 			'</div>'+
+			'<div id="susi-launcher-close" title="Close" style="display: none;">'+'</div>'+
 			'</div>'+
-				'<div id="susi-launcher-close" title="Close" style="display: none;">'+'</div>'+
 			'<div id="susi-launcher-container" class="susi-flex-center susi-avatar-launcher susi-launcher-enabled">'+
 			'<div id="susi-avatar-text">'+'Hey there'+'</div>'+
 			'<div id="susi-launcher" class="susi-launcher susi-flex-center susi-launcher-active" style="background-color: rgb(91, 75, 159);">'+
@@ -168,7 +170,7 @@ function enableBot() {
 			$('#susi-avatar-text').toggle();
 			$('#susi-launcher-close').toggle();
 		});
-		
+
 
 		// on input/text enter
 		$('#susiTextMessage').on('keyup keypress', function(e) {

--- a/src/components/Admin/Admin.css
+++ b/src/components/Admin/Admin.css
@@ -19,7 +19,6 @@
     margin-top: 30px;
     margin-left: 20px;
     margin-right: 20px;
-    background-color: #ffffff;
 }
 
 .h1{

--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -147,6 +147,11 @@ iframe{
 	height: 100%;
 	z-index: -1;
 }
+.chevron-arrow{
+	height: 35px;
+	width: 35px;
+}
+
 @media (min-width:769px){
 	.botbuilder-page-wrapper{
 		padding: 40px 30px 30px;

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -11,6 +11,8 @@ import Configure from './BotBuilderPages/Configure';
 import Deploy from './BotBuilderPages/Deploy';
 import Snackbar from 'material-ui/Snackbar';
 import { Paper } from 'material-ui';
+import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
+import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
 import Cookies from 'universal-cookie';
 
 const cookies = new Cookies();
@@ -33,6 +35,9 @@ class BotWizard extends React.Component {
       themeSettingsString: '{}',
       openSnackbar: false,
       msgSnackbar: '',
+      slideState: 1, // 0 means preview full, 1 means in middle, 2 means preview collapsed
+      colBuild: 8,
+      colPreview: 4,
     };
   }
 
@@ -87,6 +92,39 @@ class BotWizard extends React.Component {
     this.setState({ stepIndex });
   };
 
+  handleBuildToggle = () => {
+    let { slideState } = this.state;
+    if (slideState === 0 || slideState === 2) {
+      this.setState({
+        slideState: 1,
+        colBuild: 8,
+        colPreview: 4,
+      });
+    } else if (slideState === 1) {
+      this.setState({
+        slideState: 0,
+        colBuild: 0,
+        colPreview: 12,
+      });
+    }
+  };
+  handlePreviewToggle = () => {
+    let { slideState } = this.state;
+    if (slideState === 0 || slideState === 2) {
+      this.setState({
+        slideState: 1,
+        colBuild: 8,
+        colPreview: 4,
+      });
+    } else if (slideState === 1) {
+      this.setState({
+        slideState: 2,
+        colBuild: 12,
+        colPreview: 0,
+      });
+    }
+  };
+
   render() {
     if (!cookies.get('loggedIn')) {
       return (
@@ -112,101 +150,121 @@ class BotWizard extends React.Component {
       <div>
         <StaticAppBar {...this.props} />
         <div style={styles.home} className="botbuilder-page-wrapper">
-          <Paper
-            style={styles.paperStyle}
-            className="botBuilder-page-card"
-            zDepth={1}
-          >
-            <Grid fluid>
-              <Row>
-                <Col xs={12} md={8}>
-                  <div style={{ display: 'flex', flexDirection: 'row' }}>
-                    <div
-                      style={{
-                        width: '100%',
-                        maxWidth: '100%',
-                        margin: 'auto',
-                      }}
-                    >
-                      <Stepper activeStep={stepIndex} linear={false}>
-                        <Step>
-                          <StepButton onClick={() => this.setStep(0)}>
-                            Build
-                          </StepButton>
-                        </Step>
-                        <Step>
-                          <StepButton onClick={() => this.setStep(1)}>
-                            Design
-                          </StepButton>
-                        </Step>
-                        <Step>
-                          <StepButton onClick={() => this.setStep(2)}>
-                            Configure
-                          </StepButton>
-                        </Step>
-                        <Step>
-                          <StepButton onClick={() => this.setStep(3)}>
-                            Deploy
-                          </StepButton>
-                        </Step>
-                      </Stepper>
-                      <div style={contentStyle}>
-                        <div>{this.getStepContent(stepIndex)}</div>
-                        <div style={{ marginTop: '20px' }}>
-                          <RaisedButton
-                            label="Back"
-                            disabled={stepIndex === 0}
-                            backgroundColor={colors.header}
-                            labelColor="#fff"
-                            onTouchTap={this.handlePrev}
-                            style={{ marginRight: 12 }}
-                          />
-                          {stepIndex < 3 ? (
-                            <RaisedButton
-                              label={
-                                stepIndex === 2 ? 'Save and Deploy' : 'Next'
-                              }
-                              backgroundColor={colors.header}
-                              labelColor="#fff"
-                              onTouchTap={this.handleNext}
-                            />
-                          ) : (
-                            <p
-                              style={{
-                                padding: '20px 0px 0px 0px',
-                                fontFamily: 'sans-serif',
-                                fontSize: '14px',
-                              }}
-                            >
-                              You&apos;re all done. Thanks for using SUSI Bot.
-                            </p>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </Col>
-
-                <Col xs={12} md={4}>
-                  <div style={{ padding: '40px 0 0 40px' }}>
-                    <br className="display-mobile-only" />
-                    <h2 className="center">Preview</h2>
-                    <br />
-                    <div style={{ position: 'relative', overflow: 'hidden' }}>
-                      <iframe
-                        title="botPreview"
-                        name="frame-1"
-                        id="frame-1"
-                        src={locationBot}
-                        height="600"
-                        width="100%"
+          <Grid fluid>
+            <Row>
+              <Col
+                className="botbuilder-col"
+                md={this.state.colBuild}
+                style={{
+                  overflowX: 'auto',
+                  display: this.state.colBuild === 0 ? 'none' : 'block',
+                }}
+              >
+                <Paper
+                  style={styles.paperStyle}
+                  className="botBuilder-page-card"
+                  zDepth={1}
+                >
+                  <span title="collapse builder">
+                    <ChevronLeft
+                      className="botbuilder-chevron"
+                      onClick={this.handleBuildToggle}
+                      style={styles.chevronBuild}
+                    />
+                  </span>
+                  <Stepper activeStep={stepIndex} linear={false}>
+                    <Step>
+                      <StepButton onClick={() => this.setStep(0)}>
+                        Build
+                      </StepButton>
+                    </Step>
+                    <Step>
+                      <StepButton onClick={() => this.setStep(1)}>
+                        Design
+                      </StepButton>
+                    </Step>
+                    <Step>
+                      <StepButton onClick={() => this.setStep(2)}>
+                        Configure
+                      </StepButton>
+                    </Step>
+                    <Step>
+                      <StepButton onClick={() => this.setStep(3)}>
+                        Deploy
+                      </StepButton>
+                    </Step>
+                  </Stepper>
+                  <div style={contentStyle}>
+                    <div>{this.getStepContent(stepIndex)}</div>
+                    <div style={{ marginTop: '20px' }}>
+                      <RaisedButton
+                        label="Back"
+                        disabled={stepIndex === 0}
+                        backgroundColor={colors.header}
+                        labelColor="#fff"
+                        onTouchTap={this.handlePrev}
+                        style={{ marginRight: 12 }}
                       />
+                      {stepIndex < 3 ? (
+                        <RaisedButton
+                          label={stepIndex === 2 ? 'Save and Deploy' : 'Next'}
+                          backgroundColor={colors.header}
+                          labelColor="#fff"
+                          onTouchTap={this.handleNext}
+                        />
+                      ) : (
+                        <p
+                          style={{
+                            padding: '20px 0px 0px 0px',
+                            fontFamily: 'sans-serif',
+                            fontSize: '14px',
+                          }}
+                        >
+                          You&apos;re all done. Thanks for using SUSI Bot.
+                        </p>
+                      )}
                     </div>
                   </div>
-                </Col>
-              </Row>
-            </Grid>
-          </Paper>
+                </Paper>
+              </Col>
+
+              <Col
+                className="botbuilder-col"
+                xs={12}
+                md={this.state.colPreview}
+                style={{
+                  display: this.state.colPreview === 0 ? 'none' : 'block',
+                }}
+              >
+                <Paper
+                  style={styles.paperStyle}
+                  className="botBuilder-page-card"
+                  zDepth={1}
+                >
+                  <span title="collapse preview">
+                    <ChevronRight
+                      className="botbuilder-chevron"
+                      onClick={this.handlePreviewToggle}
+                      style={styles.chevronPreview}
+                    />
+                  </span>
+                  <br className="display-mobile-only" />
+                  <h2 className="center">Preview</h2>
+                  <br />
+                  <div style={{ position: 'relative', overflow: 'hidden' }}>
+                    <iframe
+                      title="botPreview"
+                      name="frame-1"
+                      id="frame-1"
+                      src={locationBot}
+                      height="600"
+                      width="100%"
+                    />
+                  </div>
+                </Paper>
+              </Col>
+            </Row>
+          </Grid>
         </div>
         <Snackbar
           open={this.state.openSnackbar}
@@ -232,6 +290,7 @@ const styles = {
   paperStyle: {
     width: '100%',
     marginTop: '20px',
+    position: 'relative',
   },
   tabStyle: {
     color: 'rgb(91, 91, 91)',
@@ -243,6 +302,24 @@ const styles = {
     marginBottom: '100px',
     fontSize: '50px',
     marginTop: '300px',
+  },
+  chevronBuild: {
+    position: 'absolute',
+    right: '0',
+    top: '0',
+    width: '35px',
+    height: '35px',
+    cursor: 'pointer',
+    display: window.innerWidth < 769 ? 'none' : 'inherit',
+  },
+  chevronPreview: {
+    position: 'absolute',
+    left: '0',
+    top: '0',
+    width: '35px',
+    height: '35px',
+    cursor: 'pointer',
+    display: window.innerWidth < 769 ? 'none' : 'inherit',
   },
 };
 BotWizard.propTypes = {


### PR DESCRIPTION
Fixes #821 

Changes: 
- minor styling improvements to the chatbot plugin
- In the `/botbuilder/botwizard` page, there are two arrow icons on the top. 
  - On pressing the arrow icon on the preview section, the preview section gets collapsed and the builder section becomes full width.
  - On pressing the arrow icon on the builder section, the builder section gets collapsed and the preview section becomes full width.

Thus user can make either of the two sections full width.

Surge Deployment Link: https://pr-846-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![slide in out gif](https://user-images.githubusercontent.com/17807257/41813373-85eb7a74-7752-11e8-9452-a12db60ad656.gif)
