### PR TITLE
Add text editor in design tab along with static design code

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -2,6 +2,7 @@ import React from 'react';
 import RaisedButton from 'material-ui/RaisedButton';
 import * as $ from 'jquery';
 import Cookies from 'universal-cookie';
+import AceEditor from 'react-ace';
 import Snackbar from 'material-ui/Snackbar';
 import TiTick from 'react-icons/lib/ti/tick';
 import CircularProgress from 'material-ui/CircularProgress';
@@ -36,6 +37,8 @@ class Design extends React.Component {
       botbuilderBodyBackgroundImgName: '',
       botbuilderIconImgName: '',
       uploadingBotbuilderIconImg: false,
+      editorTheme: 'github',
+      fontSizeCode: 14,
     };
     this.getSettings();
   }
@@ -43,10 +46,12 @@ class Design extends React.Component {
   componentDidMount() {
     this.updateSettings();
   }
+
   updateSettings = () => {
     let settingsString = JSON.stringify(this.state);
     this.props.updateSettings(settingsString);
   };
+
   handleChangeColor = (component, color) => {
     if (component === 'botbuilderIconColor') {
       this.setState(
@@ -642,53 +647,70 @@ class Design extends React.Component {
       );
     });
     return (
-      <div className="center menu-page">
-        {!this.state.loadedSettings ? (
-          <div className="center">
-            <CircularProgress size={62} color="#4285f5" />
-            <h4>Loading</h4>
-          </div>
-        ) : (
-          <div className="design-box">
-            {this.state.loadedSettings && customizeComponents}
-            <RaisedButton
-              label={
-                this.state.resetting ? (
-                  <CircularProgress color={colors.header} size={32} />
-                ) : (
-                  'Reset'
-                )
-              }
-              onTouchTap={this.handleReset}
-            />
-            <RaisedButton
-              name="save"
-              style={{ marginLeft: '15px' }}
-              disabled={
-                this.state.uploadingBodyBackgroundImg ||
-                this.state.uploadingBotbuilderIconImg
-              }
-              backgroundColor={colors.header}
-              onTouchTap={this.handleSave}
-              labelColor="#fff"
-              label={
-                this.state.saving ? (
-                  <CircularProgress color="#ffffff" size={32} />
-                ) : (
-                  'Save Changes'
-                )
-              }
-            />
-          </div>
-        )}
-        <Snackbar
-          open={this.state.openSnackbar}
-          message={this.state.msgSnackbar}
-          autoHideDuration={2000}
-          onRequestClose={() => {
-            this.setState({ openSnackbar: false });
-          }}
-        />
+      <div>
+        <div style={{ padding: '20px 10px 0 10px' }}>
+          <AceEditor
+            mode="java"
+            theme={this.state.editorTheme}
+            width="100%"
+            fontSize={this.state.fontSizeCode}
+            height="200px"
+            value={this.props.code}
+            showPrintMargin={false}
+            name="skill_code_editor"
+            scrollPastEnd={false}
+            wrapEnabled={true}
+            editorProps={{ $blockScrolling: true }}
+          />
+        </div>
+        <div className="center menu-page">
+          {!this.state.loadedSettings ? (
+            <div className="center">
+              <CircularProgress size={62} color="#4285f5" />
+              <h4>Loading</h4>
+            </div>
+          ) : (
+            <div className="design-box">
+              {this.state.loadedSettings && customizeComponents}
+              <RaisedButton
+                label={
+                  this.state.resetting ? (
+                    <CircularProgress color={colors.header} size={32} />
+                  ) : (
+                    'Reset'
+                  )
+                }
+                onTouchTap={this.handleReset}
+              />
+              <RaisedButton
+                name="save"
+                style={{ marginLeft: '15px' }}
+                disabled={
+                  this.state.uploadingBodyBackgroundImg ||
+                  this.state.uploadingBotbuilderIconImg
+                }
+                backgroundColor={colors.header}
+                onTouchTap={this.handleSave}
+                labelColor="#fff"
+                label={
+                  this.state.saving ? (
+                    <CircularProgress color="#ffffff" size={32} />
+                  ) : (
+                    'Save Changes'
+                  )
+                }
+              />
+            </div>
+          )}
+          <Snackbar
+            open={this.state.openSnackbar}
+            message={this.state.msgSnackbar}
+            autoHideDuration={2000}
+            onRequestClose={() => {
+              this.setState({ openSnackbar: false });
+            }}
+          />
+        </div>
       </div>
     );
   }
@@ -696,6 +718,7 @@ class Design extends React.Component {
 
 Design.propTypes = {
   updateSettings: PropTypes.func,
+  code: PropTypes.string,
 };
 
 export default Design;

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -38,6 +38,8 @@ class BotWizard extends React.Component {
       slideState: 1, // 0 means preview full, 1 means in middle, 2 means preview collapsed
       colBuild: 8,
       colPreview: 4,
+      designCode:
+        '!Write the hex color codes of Body background, User message box background, User message text color, Bot message box background, Bot message text color and Bot Icon respectively below.\n::design #ffffff, #0077e5, #ffffff, #f8f8f8, #455a64, #000000',
     };
   }
 
@@ -79,7 +81,12 @@ class BotWizard extends React.Component {
       case 0:
         return <Build code={this.state.startCode} />;
       case 1:
-        return <Design updateSettings={this.updateSettings} />;
+        return (
+          <Design
+            updateSettings={this.updateSettings}
+            code={this.state.designCode}
+          />
+        );
       case 2:
         return <Configure />;
       case 3:


### PR DESCRIPTION
Fixes #825 
Changes: Added text editor in design tab along with static design code to store design details in the skill language code format in `protected` skills.
This PR doesn't implement saving of these settings. That will be done in upcoming PRs.

Surge Deployment Link: https://pr-861-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
<img width="669" alt="screen shot 2018-06-25 at 4 30 30 pm" src="https://user-images.githubusercontent.com/31174685/41846887-d0b5ed48-7895-11e8-8937-4e0979e167d2.png">

