### PR TITLE
Fixes #858: Add links to Category on sidebar

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -121,22 +121,24 @@ export default class BrowseSkill extends React.Component {
           this.setState({ groups: data });
           data.sort();
           groups.push(
-            <MenuItem
-              value="All"
-              key="All"
-              primaryText="All"
-              onClick={event => this.handleGroupChange(event, 'All')}
-            />,
+            <Link to="/category/All" key="All">
+              <MenuItem
+                value="All"
+                primaryText="All"
+                style={{ minHeight: '32px', lineHeight: '32px' }}
+              />
+            </Link>,
           );
 
           for (let i = 0; i < data.length; i++) {
             groups.push(
-              <MenuItem
-                value={data[i]}
-                key={data[i]}
-                primaryText={`${data[i]}`}
-                onClick={event => this.handleGroupChange(event, data[i])}
-              />,
+              <Link to={'/category/' + data[i]} key={data[i]}>
+                <MenuItem
+                  value={data[i]}
+                  primaryText={`${data[i]}`}
+                  style={{ minHeight: '32px', lineHeight: '32px' }}
+                />
+              </Link>,
             );
           }
         }.bind(this),


### PR DESCRIPTION
Fixes #858 

Changes: 
* Add links to Category on sidebar to show category wise skills

Surge Deployment Link: https://pr-865-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![peek 2018-06-26 10-16](https://user-images.githubusercontent.com/12656846/41889792-0e9aeffc-792a-11e8-98d6-aa7a0faa060b.gif)

