### PR TITLE
Parse country wise usage by country code

### DIFF
--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -287,7 +287,7 @@ class SkillListing extends Component {
   saveCountryWiseSkillUsage = (country_wise_skill_usage = []) => {
     // Add sample data to test
     let data = country_wise_skill_usage.map(country => [
-      country.country_name,
+      country.country_code,
       parseInt(country.count, 10),
     ]);
 


### PR DESCRIPTION
Fixes #875 

Changes: 
Parsed usage details by country code instead of country name.

Surge Deployment Link: https://susi--cms.surge.sh

Screenshots for the change:
No visual changes.