### PR TITLE
Fixes #870: Prevent overlap of legends and pie describers

### DIFF
--- a/src/components/SkillUsageCard/SkillUsageCard.js
+++ b/src/components/SkillUsageCard/SkillUsageCard.js
@@ -131,9 +131,7 @@ class SkillUsageCard extends Component {
                           />
                         ))}
                       </Pie>
-                      <Legend
-                        margin={{ top: 10, left: 0, right: 0, bottom: 10 }}
-                      />
+                      <Legend wrapperStyle={{ position: 'relative' }} />
                     </PieChart>
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #870 

Changes: Enforce relative position for the legends wrapper. I know using !important is not that good but Legends component has an inline position absolute style which doesn't seem to overwrite in several methods I tried, tried changing the style using the DOM element in CDM but that sometimes work and sometimes not, so I think this is the most ideal solution. 

Surge Deployment Link: https://pr-879-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/41966051-b8efaa3c-7a1b-11e8-86d7-3c3e552a9211.png)
