### PR TITLE
Fixes #880: Always load cards even then server hits 503 once

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -261,6 +261,7 @@ export default class BrowseSkill extends React.Component {
       },
       error: function(e) {
         console.log('Error while fetching skills', e);
+        return self.loadCards();
       },
     });
   };
@@ -285,6 +286,7 @@ export default class BrowseSkill extends React.Component {
       },
       error: function(e) {
         console.log('Error while fetching top rated skills', e);
+        return self.loadTopRated();
       },
     });
   };


### PR DESCRIPTION
Fixes #880 

Changes: Try fetching skills again once failed.
Note: This is a workaround for now by the time the issue is fixed on the server.

Surge Deployment Link: https://pr-881-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
Skills are loaded even when skills failed to fetch initially
![image](https://user-images.githubusercontent.com/21009455/41970005-e1dd5d12-7a26-11e8-953d-08613e2aca2f.png)
