### PR TITLE
Fixes #886: Format code before running through eslint checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,8 +67,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "lint-js": "eslint *.js \"src/**/*.js\"",
-    "lint": "npm run lint-js",
+    "lint": "eslint *.js \"src/**/*.js\"",
     "precommit": "lint-staged",
     "format": "prettier --write \"src/**/*.js\"",
     "prepush": "npm run lint",
@@ -79,9 +78,9 @@
   },
   "lint-staged": {
     "src/**/*.js": [
-      "eslint src --ext .js",
       "prettier --write",
-      "git add"
+      "eslint --fix",
+      "git add ."
     ]
   }
 }


### PR DESCRIPTION
Fixes #886 

Changes: Format code before running through eslint checks which saves an extra step of using `npm run format` when eslint checks fail.

Surge Deployment Link: https://pr-887-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
There were linting errors yet the commit succeeded.
![image](https://user-images.githubusercontent.com/21009455/42012462-e8a20e1a-7ab5-11e8-9f14-705ce5c6e6d8.png)
