### PR TITLE
Fixes #690: Make auth related cookies persistent over all susi.ai domains

### DIFF
--- a/src/components/Auth/Login/Login.js
+++ b/src/components/Auth/Login/Login.js
@@ -84,7 +84,10 @@ class Login extends Component {
         crossDomain: true,
         success: function(response) {
           if (response.accepted) {
-            cookies.set('serverUrl', BASE_URL, { path: '/' });
+            cookies.set('serverUrl', BASE_URL, {
+              path: '/',
+              domain: '.susi.ai',
+            });
             console.log(cookies.get('serverUrl'));
             let accessToken = response.access_token;
             let state = this.state;
@@ -163,8 +166,16 @@ class Login extends Component {
   handleOnSubmit = (email, loggedIn, showAdmin, time) => {
     let state = this.state;
     if (state.success) {
-      cookies.set('loggedIn', loggedIn, { path: '/', maxAge: time });
-      cookies.set('emailId', this.state.email, { path: '/', maxAge: time });
+      cookies.set('loggedIn', loggedIn, {
+        path: '/',
+        maxAge: time,
+        domain: '.susi.ai',
+      });
+      cookies.set('emailId', this.state.email, {
+        path: '/',
+        maxAge: time,
+        domain: '.susi.ai',
+      });
       this.props.history.push('/', { showLogin: false });
       window.location.reload();
     } else {

--- a/src/components/Auth/Logout.react.js
+++ b/src/components/Auth/Logout.react.js
@@ -1,8 +1,15 @@
 import { Component } from 'react';
 import PropTypes from 'prop-types';
 
-var deleteCookie = function(name) {
-  document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+var deleteCookie = function(name, options = {}) {
+  let cookieString = `${name}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+  if (options.domain) {
+    cookieString = `${cookieString}domain=${options.domain};`;
+  }
+  if (options.path) {
+    cookieString = `${cookieString}path=${options.path};`;
+  }
+  document.cookie = cookieString;
 };
 
 class Logout extends Component {
@@ -15,11 +22,11 @@ class Logout extends Component {
   }
 
   componentDidMount() {
-    deleteCookie('loggedIn');
-    deleteCookie('serverUrl');
-    deleteCookie('email');
-    deleteCookie('showAdmin');
-    deleteCookie('username');
+    deleteCookie('loggedIn', { domain: '.susi.ai', path: '/' });
+    deleteCookie('serverUrl', { domain: '.susi.ai', path: '/' });
+    deleteCookie('emailId', { domain: '.susi.ai', path: '/' });
+    deleteCookie('showAdmin', { path: '/' });
+    deleteCookie('username', { domain: '.susi.ai', path: '/' });
     this.props.history.push('/');
     window.location.reload();
   }

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -87,7 +87,9 @@ class StaticAppBar extends Component {
         crossDomain: true,
         success: function(newResponse) {
           let ShowAdmin = newResponse.showAdmin;
-          cookies.set('showAdmin', ShowAdmin);
+          cookies.set('showAdmin', ShowAdmin, {
+            path: '/',
+          });
           this.setState({
             showAdmin: ShowAdmin,
           });
@@ -109,7 +111,10 @@ class StaticAppBar extends Component {
         crossDomain: true,
         success: function(data) {
           let userName = data.settings.userName;
-          cookies.set('username', userName);
+          cookies.set('username', userName, {
+            path: '/',
+            domain: '.susi.ai',
+          });
         },
         error: function(errorThrown) {
           console.log(errorThrown);


### PR DESCRIPTION
Fixes #690 

Changes: [Add here what changes were made in this issue and if possible provide links.]
* The cookies that are set during login must persist in all domains of SUSI.

Surge Deployment Link: http://satisfying-camera.surge.sh/

Note: This deployment links is an example for `*.surge.sh` domain types. You can try logging in from this link and then open https://pr-301-fossasia-susi-accounts.surge.sh to check that the cookies still persist. Also, for testing, you need to first remove the cookies for all the *.surge.sh websites from browser settings.

Screenshots for the change:
NA
