### PR TITLE
Indent hex codes and improve UI of design tab

### DIFF
--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -24,7 +24,6 @@
 	display: block;
 }
 .design-box{
-	width: 400px;
 	max-width: 100%;
 	text-align: left;
 }

--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -2,6 +2,7 @@ import React from 'react';
 import RaisedButton from 'material-ui/RaisedButton';
 import * as $ from 'jquery';
 import Cookies from 'universal-cookie';
+import { Grid, Col, Row } from 'react-flexbox-grid';
 import AceEditor from 'react-ace';
 import Snackbar from 'material-ui/Snackbar';
 import TiTick from 'react-icons/lib/ti/tick';
@@ -532,24 +533,37 @@ class Design extends React.Component {
     const customizeComponents = customiseOptionsList.map(component => {
       return (
         <div key={component.id} className="circleChoose">
-          <h2>Color of {component.name}</h2>
-          <div className="color-picker-wrap">
-            <ColorPicker
-              className="color-picker"
-              style={{ display: 'inline-block', float: 'left' }}
-              name="color"
-              id={'colorPicker' + component.id}
-              defaultValue={this.state[component.component]}
-              onChange={color =>
-                this.handleChangeColor(component.component, color)
-              }
-            />
-            <span
-              className="color-box"
-              onClick={() => this.handleClickColorBox(component.id)}
-              style={{ backgroundColor: this.state[component.component] }}
-            />
-          </div>
+          <Grid>
+            <Row>
+              <Col xs={12} md={6} lg={6}>
+                <h2>Color of {component.name}</h2>
+              </Col>
+              <Col xs={12} md={6} lg={6}>
+                <div style={{ display: 'flex', flexDirection: 'row' }}>
+                  <div className="color-picker-wrap">
+                    <ColorPicker
+                      className="color-picker"
+                      style={{ display: 'inline-block', float: 'left' }}
+                      name="color"
+                      id={'colorPicker' + component.id}
+                      defaultValue={this.state[component.component]}
+                      onChange={color =>
+                        this.handleChangeColor(component.component, color)
+                      }
+                    />
+                    <span
+                      className="color-box"
+                      onClick={() => this.handleClickColorBox(component.id)}
+                      style={{
+                        backgroundColor: this.state[component.component],
+                      }}
+                    />
+                  </div>
+                </div>
+              </Col>
+            </Row>
+          </Grid>
+
           {component.component === 'botbuilderBackgroundBody' && (
             <div>
               <br />

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -39,7 +39,7 @@ class BotWizard extends React.Component {
       colBuild: 8,
       colPreview: 4,
       designCode:
-        '!Write the hex color codes of Body background, User message box background, User message text color, Bot message box background, Bot message text color and Bot Icon respectively below.\n::design #ffffff, #0077e5, #ffffff, #f8f8f8, #455a64, #000000',
+        '::design\n  color\n    bodyBackground #ffffff,\n    userMessageBoxBackground #0077e5,\n    userMessageTextColor #ffffff,\n    botMessageBoxBackground #f8f8f8,\n    botMessageTextColor #455a64,\n    botIconColor #000000',
       configCode:
         '!Write the status of each website you want to enable or disable the bot below.\n::sites_enabled website1.com, website2.com\n::sites_disabled website3.com',
     };


### PR DESCRIPTION
Partially fixes issue #896 

Changes: Indented the hex codes and added text field after 

Surge Deployment Link: https://pr-905-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

<img width="740" alt="screen shot 2018-06-29 at 6 21 14 pm" src="https://user-images.githubusercontent.com/31174685/42094063-2903538a-7bcc-11e8-89aa-ee83990b42cd.png">

<img width="705" alt="screen shot 2018-06-29 at 6 21 21 pm" src="https://user-images.githubusercontent.com/31174685/42094066-2ad02cec-7bcc-11e8-808a-955d999ff305.png">

