### PR TITLE
Made the "save bot" card visible on all steps in botbuilder

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -7,10 +7,11 @@ import colors from '../../Utils/colors';
 import Build from './BotBuilderPages/Build';
 import PropTypes from 'prop-types';
 import Design from './BotBuilderPages/Design';
+import { Link } from 'react-router-dom';
 import Configure from './BotBuilderPages/Configure';
 import Deploy from './BotBuilderPages/Deploy';
 import Snackbar from 'material-ui/Snackbar';
-import { Paper } from 'material-ui';
+import { Paper, TextField } from 'material-ui';
 import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
 import Cookies from 'universal-cookie';
@@ -134,6 +135,16 @@ class BotWizard extends React.Component {
     }
   };
 
+  handleCommitMessageChange = event => {
+    this.setState({
+      commitMessage: event.target.value,
+    });
+  };
+
+  saveClick = () => {
+    // save the skill on the server
+  };
+
   render() {
     if (!cookies.get('loggedIn')) {
       return (
@@ -205,35 +216,58 @@ class BotWizard extends React.Component {
                   </Stepper>
                   <div style={contentStyle}>
                     <div>{this.getStepContent(stepIndex)}</div>
-                    <div style={{ marginTop: '20px' }}>
-                      <RaisedButton
-                        label="Back"
-                        disabled={stepIndex === 0}
-                        backgroundColor={colors.header}
-                        labelColor="#fff"
-                        onTouchTap={this.handlePrev}
-                        style={{ marginRight: 12 }}
-                      />
-                      {stepIndex < 3 ? (
-                        <RaisedButton
-                          label={stepIndex === 2 ? 'Save and Deploy' : 'Next'}
-                          backgroundColor={colors.header}
-                          labelColor="#fff"
-                          onTouchTap={this.handleNext}
-                        />
-                      ) : (
-                        <p
-                          style={{
-                            padding: '20px 0px 0px 0px',
-                            fontFamily: 'sans-serif',
-                            fontSize: '14px',
-                          }}
-                        >
-                          You&apos;re all done. Thanks for using SUSI Bot.
-                        </p>
-                      )}
-                    </div>
+                    <div style={{ marginTop: '20px' }} />
                   </div>
+                </Paper>
+                <Paper
+                  style={styles.paperStyle}
+                  className="botBuilder-page-card"
+                  zDepth={1}
+                >
+                  <RaisedButton
+                    label="Back"
+                    disabled={stepIndex === 0}
+                    backgroundColor={colors.header}
+                    labelColor="#fff"
+                    onTouchTap={this.handlePrev}
+                    style={{ marginRight: 12 }}
+                  />
+                  {stepIndex < 3 ? (
+                    <RaisedButton
+                      label={stepIndex === 2 ? 'Save and Deploy' : 'Next'}
+                      backgroundColor={colors.header}
+                      labelColor="#fff"
+                      onTouchTap={this.handleNext}
+                    />
+                  ) : (
+                    <p
+                      style={{
+                        padding: '20px 0px 0px 0px',
+                        fontFamily: 'sans-serif',
+                        fontSize: '14px',
+                      }}
+                    >
+                      You&apos;re all done. Thanks for using SUSI Bot.
+                    </p>
+                  )}
+                  <TextField
+                    floatingLabelText="Commit message"
+                    floatingLabelFixed={true}
+                    hintText="Enter Commit Message"
+                    style={{ width: '80%' }}
+                    onChange={this.handleCommitMessageChange}
+                  />
+                  <br />
+                  <Link to="/botbuilder">
+                    <RaisedButton label="Cancel" />
+                  </Link>
+                  <RaisedButton
+                    label="Save"
+                    backgroundColor={colors.header}
+                    labelColor="#fff"
+                    style={{ marginLeft: 10 }}
+                    onTouchTap={this.saveClick}
+                  />
                 </Paper>
               </Col>
 

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -564,40 +564,42 @@ export default class CreateSkill extends React.Component {
               marginTop: 10,
             }}
           >
-            <Paper
-              style={{
-                width: '100%',
-                padding: 10,
-                display: 'flex',
-                alignItems: 'center',
-                textAlign: 'center',
-                justifyContent: 'center',
-              }}
-              zDepth={1}
-            >
-              <TextField
-                floatingLabelText="Commit message"
-                floatingLabelFixed={true}
-                hintText="Enter Commit Message"
-                style={{ width: '80%' }}
-                onChange={this.handleCommitMessageChange}
-              />
-              <RaisedButton
-                label="Save"
-                backgroundColor={colors.header}
-                labelColor="#fff"
-                style={{ marginLeft: 10 }}
-                onTouchTap={this.saveClick}
-              />
-              <Link to="/">
+            {!this.props.botBuilder && (
+              <Paper
+                style={{
+                  width: '100%',
+                  padding: 10,
+                  display: 'flex',
+                  alignItems: 'center',
+                  textAlign: 'center',
+                  justifyContent: 'center',
+                }}
+                zDepth={1}
+              >
+                <TextField
+                  floatingLabelText="Commit message"
+                  floatingLabelFixed={true}
+                  hintText="Enter Commit Message"
+                  style={{ width: '80%' }}
+                  onChange={this.handleCommitMessageChange}
+                />
                 <RaisedButton
-                  label="Cancel"
+                  label="Save"
                   backgroundColor={colors.header}
                   labelColor="#fff"
                   style={{ marginLeft: 10 }}
+                  onTouchTap={this.saveClick}
                 />
-              </Link>
-            </Paper>
+                <Link to="/">
+                  <RaisedButton
+                    label="Cancel"
+                    backgroundColor={colors.header}
+                    labelColor="#fff"
+                    style={{ marginLeft: 10 }}
+                  />
+                </Link>
+              </Paper>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fixes #892 

Changes: 
- Made the "Save bot" card including the commit message textbox stay on the bottom for all steps in the botbuilder. (previously this was visible only on the build page)
- Made the "Cancel" button go back to the `/botbuilder` page instead of the homepage.

(The actual saving of the skills on the server will be done in subsequent PRs after we have combined all the code views for different section such as design, configure)

Surge Deployment Link: https://pr-906-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17807257/42114467-c8e25aaa-7c0c-11e8-874a-04756c07c169.png)

