### PR TITLE
Add icon and tooltip for helper text in botbuilder

### DIFF
--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -190,6 +190,13 @@ iframe{
 input[type=file]{
 	display: none;
 }
+.tooltipSkill {
+	pointer-events: auto;
+}
+.tooltipSkill:hover {
+	visibility: visible;
+	opacity: 1;
+}
 
 @media (min-width:769px){
 	.botbuilder-page-wrapper{

--- a/src/components/BotBuilder/BotBuilderPages/BuildViews/CodeView.js
+++ b/src/components/BotBuilder/BotBuilderPages/BuildViews/CodeView.js
@@ -14,17 +14,6 @@ class CodeView extends Component {
     return (
       <div>
         <div>
-          <h3>
-            Know more about{' '}
-            <a
-              href="https://github.com/fossasia/susi_skill_cms/blob/master/docs/Skill_Tutorial.md"
-              rel="noopener noreferrer"
-              target="_blank"
-            >
-              SUSI Skill Language
-            </a>
-          </h3>
-          <br />
           <CreateSkill botBuilder={this.props.botBuilder} />
         </div>
       </div>

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -3,6 +3,7 @@ import Icon from 'antd/lib/icon';
 import MenuItem from 'material-ui/MenuItem';
 import PropTypes from 'prop-types';
 import SelectField from 'material-ui/SelectField';
+import ReactTooltip from 'react-tooltip';
 import ISO6391 from 'iso-639-1';
 import { Paper, RaisedButton, TextField } from 'material-ui';
 import AceEditor from 'react-ace';
@@ -22,6 +23,7 @@ import 'brace/theme/solarized_light';
 import 'brace/theme/terminal';
 import * as $ from 'jquery';
 import notification from 'antd/lib/notification';
+import Info from 'material-ui/svg-icons/action/info';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import LinearProgress from 'material-ui/LinearProgress';
 import colors from '../../Utils/colors';
@@ -414,6 +416,7 @@ export default class CreateSkill extends React.Component {
     const style = {
       width: '100%',
       padding: '10px',
+      position: 'relative',
     };
     if (!cookies.get('loggedIn')) {
       return (
@@ -434,7 +437,21 @@ export default class CreateSkill extends React.Component {
             padding: this.props.botBuilder ? '0px' : '80px 30px 30px',
           }}
         >
+          <ReactTooltip
+            effect="solid"
+            place="bottom"
+            className="tooltipSkill"
+            delayHide={500}
+            html={true}
+          />
           <Paper style={style} zDepth={1}>
+            <Info
+              style={styles.helpIcon}
+              isCapture={true}
+              data-tip={
+                'Know more about <a href="https://github.com/fossasia/susi_skill_cms/blob/master/docs/Skill_Tutorial.md" rel="noopener noreferrer" target="_blank" >SUSI Skill Language</a>'
+              }
+            />
             <div style={styles.center}>
               <div style={styles.dropdownDiv}>
                 <SelectField
@@ -661,6 +678,15 @@ const styles = {
     left: 0,
     width: '100%',
     opacity: 0,
+  },
+  helpIcon: {
+    position: 'absolute',
+    top: '10px',
+    right: '10px',
+    height: '20px',
+    width: '20px',
+    cursor: 'pointer',
+    color: 'rgb(158, 158, 158)',
   },
 };
 CreateSkill.propTypes = {


### PR DESCRIPTION
Fixes #891 

Changes: 
- Add `Info` icon for showing information about skills which when hovered upon opens a tooltip
- Add the SUSI Skill language tutorial link in the tooltip
- Reduce the space at the top in codeview

Surge Deployment Link: https://pr-913-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
Icon:
![image](https://user-images.githubusercontent.com/17807257/42175804-67e0d9a4-7e44-11e8-921e-ee4f5cb36288.png)

Tooltip:
![susi_skill_tooltip_hover](https://user-images.githubusercontent.com/17807257/42175814-705560a0-7e44-11e8-92fc-df64c6c1a792.gif)


