### PR TITLE
Added duration parameter in the Top Used Skills

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -311,7 +311,7 @@ export default class BrowseSkill extends React.Component {
     let url;
     url =
       urls.API_URL +
-      '/cms/getSkillList.json?group=All&applyFilter=true&filter_name=descending&filter_type=usage&count=10';
+      '/cms/getSkillList.json?group=All&applyFilter=true&filter_name=descending&filter_type=usage&count=10&duration=30';
     let self = this;
     $.ajax({
       url: url,


### PR DESCRIPTION
Fixes #923 

Changes: 
Fetched the top used skills of the month, ie, duration=30

Surge Deployment Link: https://susi--cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/10573038/42167781-aefb35d6-7e2c-11e8-922e-948b6fdd268f.png)
