### PR TITLE
Fixes #931: Use skill_tag for routing on Skill Card click

### DIFF
--- a/src/components/SkillCardList/SkillCardList.js
+++ b/src/components/SkillCardList/SkillCardList.js
@@ -85,7 +85,7 @@ class SkillCardList extends Component {
                 '/' +
                 skill.group +
                 '/' +
-                skill_name.toLowerCase().replace(/ /g, '_') +
+                skill.skill_tag +
                 '/' +
                 this.props.languageValue,
               state: {

--- a/src/components/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/SkillCardScrollList/SkillCardScrollList.js
@@ -97,7 +97,7 @@ class SkillCardScrollList extends Component {
                 '/' +
                 skill.group +
                 '/' +
-                skill_name.toLowerCase().replace(/ /g, '_') +
+                skill.skill_tag +
                 '/' +
                 this.props.languageValue,
               state: {


### PR DESCRIPTION
Fixes #931 

Changes: [Add here what changes were made in this issue and if possible provide links.]
* Use skill_tag for routing on Skill Card click

Surge Deployment Link: https://pr-932-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
NA