### PR TITLE
Fixes #934: Display only native languages in dropdown

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -32,7 +32,7 @@ import Ratings from 'react-ratings-declarative';
 import './custom.css';
 
 let groups = [];
-const languages = [];
+let languages = [];
 
 export default class BrowseSkill extends React.Component {
   constructor(props) {
@@ -172,13 +172,10 @@ export default class BrowseSkill extends React.Component {
           if (data) {
             data.sort();
             this.setState({ languages: data });
+            languages = [];
             for (let i = 0; i < data.length; i++) {
               if (ISO6391.getNativeName(data[i])) {
                 let languageName = ISO6391.getNativeName(data[i]);
-                if (ISO6391.getName(data[i])) {
-                  languageName =
-                    languageName + ' (' + ISO6391.getName(data[i]) + ')';
-                }
                 languages.push(
                   <MenuItem
                     value={data[i]}


### PR DESCRIPTION
Fixes #934 

Changes: Displayed only native (single) language in dropdown

Surge Deployment Link: https://pr-935-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/42185964-6ad90b30-7e68-11e8-8c46-623abec1fc98.png)
