### PR TITLE
Scroll through all cards on screen when arrows are clicked

### DIFF
--- a/src/components/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/SkillCardScrollList/SkillCardScrollList.js
@@ -18,12 +18,38 @@ class SkillCardScrollList extends Component {
     this.state = {
       cards: [],
       skills: this.props.skills,
+      scrollCards: 4,
     };
   }
 
-  componentDidMount() {
+  componentDidMount = () => {
     this.loadSkillCards();
-  }
+    this.updateWindowDimensions();
+    window.addEventListener('resize', this.updateWindowDimensions);
+  };
+
+  componentWillUnmount = () => {
+    window.removeEventListener('resize', this.updateWindowDimensions);
+  };
+
+  updateWindowDimensions = () => {
+    let scrollCards = 1;
+    switch (true) {
+      case window.innerWidth >= 1400:
+        scrollCards = 4;
+        break;
+      case window.innerWidth >= 1120:
+        scrollCards = 3;
+        break;
+      case window.innerWidth >= 840:
+        scrollCards = 2;
+        break;
+    }
+
+    this.setState({
+      scrollCards: scrollCards,
+    });
+  };
 
   componentDidUpdate() {
     if (this.props.skills !== this.state.skills) {
@@ -38,7 +64,7 @@ class SkillCardScrollList extends Component {
 
   scrollLeft = () => {
     let parentEle = document.getElementById(this.props.scrollId);
-    let scrollValue = $(parentEle).scrollLeft() - 275;
+    let scrollValue = $(parentEle).scrollLeft() - 280 * this.state.scrollCards;
     $(parentEle)
       .stop()
       .animate({ scrollLeft: scrollValue }, 100);
@@ -46,7 +72,7 @@ class SkillCardScrollList extends Component {
 
   scrollRight = () => {
     let parentEle = document.getElementById(this.props.scrollId);
-    let scrollValue = $(parentEle).scrollLeft() + 275;
+    let scrollValue = $(parentEle).scrollLeft() + 280 * this.state.scrollCards;
     $(parentEle)
       .stop()
       .animate({ scrollLeft: scrollValue }, 100);


### PR DESCRIPTION
Fixes #937 

Changes: Scroll through all cards present on screen when arrows are clicked.

Surge Deployment Link: https://pr-941-fossasia-susi-skill-cms.surge.sh
Alternate link: http://brash-decision.surge.sh/

Screenshots for the change:

Before:
![scrollentirecardold](https://user-images.githubusercontent.com/31135861/42201179-3b51934a-7eb4-11e8-8c05-5d021702ff3b.gif)

After:
![scrollthroughallcardsonscreen](https://user-images.githubusercontent.com/31135861/42201180-3b91b88a-7eb4-11e8-8a2a-ad4a483883d0.gif)
