### PR TITLE
Fixes #954: Make search bar functional on start page

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -705,7 +705,8 @@ export default class BrowseSkill extends React.Component {
 
             {this.state.skillsLoaded ? (
               <div style={styles.container}>
-                {this.state.topRatedSkills.length ? (
+                {this.state.topRatedSkills.length &&
+                !this.state.searchQuery.length ? (
                   <div style={styles.topSkills}>
                     <div
                       style={styles.metricsHeader}
@@ -726,7 +727,8 @@ export default class BrowseSkill extends React.Component {
                   </div>
                 ) : null}
 
-                {this.state.topUsedSkills.length ? (
+                {this.state.topUsedSkills.length &&
+                !this.state.searchQuery.length ? (
                   <div style={styles.topSkills}>
                     <div
                       style={styles.metricsHeader}
@@ -747,7 +749,8 @@ export default class BrowseSkill extends React.Component {
                   </div>
                 ) : null}
 
-                {this.state.skills.length && this.props.routeType ? (
+                {(this.state.skills.length && this.props.routeType) ||
+                (this.state.searchQuery.length && this.state.skills.length) ? (
                   <div>
                     <SkillCardList
                       skills={this.state.skills}
@@ -758,7 +761,8 @@ export default class BrowseSkill extends React.Component {
                   </div>
                 ) : (
                   <div>
-                    {this.props.routeType ? (
+                    {this.props.routeType ||
+                    this.state.searchQuery.length > 0 ? (
                       <div style={{ fontSize: 30 }}>
                         No Skills found. Be the first one to
                         <Link to="/skillCreator"> create</Link> a skill in this


### PR DESCRIPTION
Fixes #954, #925 

Changes: Simple condition checks to render cards when there is a search query present, there's a small bug still which I'm not able to fix, it shows up no skills found initially but when data returns it shows cards.

Surge Deployment Link: https://pr-959-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/42262916-43e846c6-7f8a-11e8-8dd8-bc0cbdfb198b.png)
