### PR TITLE
Show category and language in code view

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -11,7 +11,7 @@ class Build extends Component {
   constructor(props) {
     super(props);
     let skillCode =
-      '::name <bot_name>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query';
+      '::name <Skill_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query';
     if (this.props.code) {
       skillCode = this.props.code;
     }

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -60,7 +60,7 @@ export default class CreateSkill extends React.Component {
       languageValue: null,
       expertValue: '',
       code:
-        '::name <Skill_name>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query',
+        '::name <Skill_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query',
       fontSizeCode: 14,
       editorTheme: 'github',
       groups: [],
@@ -101,11 +101,31 @@ export default class CreateSkill extends React.Component {
   onChange(newValue) {
     const match = newValue.match(/^::image\s(.*)$/m);
     const nameMatch = newValue.match(/^::name\s(.*)$/m);
+    const categoryMatch = newValue.match(/^::category\s(.*)$/m);
+    const languageMatch = newValue.match(/^::language\s(.*)$/m);
 
     if (nameMatch) {
       self.setState(
         {
           expertValue: nameMatch[1],
+        },
+        () => self.sendInfoToProps(),
+      );
+    }
+
+    if (categoryMatch) {
+      self.setState(
+        {
+          groupValue: categoryMatch[1],
+        },
+        () => self.sendInfoToProps(),
+      );
+    }
+
+    if (languageMatch) {
+      self.setState(
+        {
+          languageValue: languageMatch[1],
         },
         () => self.sendInfoToProps(),
       );
@@ -187,11 +207,16 @@ export default class CreateSkill extends React.Component {
   };
 
   handleGroupChange = (event, index, value) => {
+    const code = this.state.code.replace(
+      /^::category\s(.*)$/m,
+      `::category ${value}`,
+    );
     this.setState(
       {
         groupValue: value,
         groupSelect: false,
         languageSelect: false,
+        code,
       },
       () => self.sendInfoToProps(),
     );
@@ -223,7 +248,8 @@ export default class CreateSkill extends React.Component {
               );
             }
             if (data[i] === 'en') {
-              this.setState({ languageValue: 'en', expertSelect: false });
+              this.handleLanguageChange(null, 0, 'en');
+              this.setState({ expertSelect: false });
             }
           }
           languages.sort(function(a, b) {
@@ -244,10 +270,16 @@ export default class CreateSkill extends React.Component {
   };
 
   handleLanguageChange = (event, index, value) => {
+    const code = this.state.code.replace(
+      /^::language\s(.*)$/m,
+      `::language ${value}`,
+    );
+
     this.setState(
       {
         languageValue: value,
         expertSelect: false,
+        code,
       },
       () => self.sendInfoToProps(),
     );


### PR DESCRIPTION
Fixes #952 

Changes: 
- add category and language values in the code view of creating public skill and in botbuilder

Surge Deployment Link: https://pr-960-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17807257/42289689-b0472b44-7fde-11e8-9d44-83c4101fd1f8.png)
