### PR TITLE
Fixes #968: Make rating_refine work on start page

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -328,13 +328,8 @@ export default class BrowseSkill extends React.Component {
     });
   };
 
-  handleRatingRefine = rating => {
-    this.setState(
-      {
-        rating_refine: rating,
-      },
-      this.loadCards(),
-    );
+  handleRatingRefine = rating_refine => {
+    this.setState({ rating_refine }, this.loadCards());
   };
 
   render() {
@@ -706,7 +701,8 @@ export default class BrowseSkill extends React.Component {
             {this.state.skillsLoaded ? (
               <div style={styles.container}>
                 {this.state.topRatedSkills.length &&
-                !this.state.searchQuery.length ? (
+                !this.state.searchQuery.length &&
+                !this.state.rating_refine ? (
                   <div style={styles.topSkills}>
                     <div
                       style={styles.metricsHeader}
@@ -728,7 +724,8 @@ export default class BrowseSkill extends React.Component {
                 ) : null}
 
                 {this.state.topUsedSkills.length &&
-                !this.state.searchQuery.length ? (
+                !this.state.searchQuery.length &&
+                !this.state.rating_refine ? (
                   <div style={styles.topSkills}>
                     <div
                       style={styles.metricsHeader}
@@ -750,7 +747,8 @@ export default class BrowseSkill extends React.Component {
                 ) : null}
 
                 {(this.state.skills.length && this.props.routeType) ||
-                (this.state.searchQuery.length && this.state.skills.length) ? (
+                (this.state.searchQuery.length && this.state.skills.length) ||
+                this.state.rating_refine ? (
                   <div>
                     <SkillCardList
                       skills={this.state.skills}


### PR DESCRIPTION
Fixes #968 

Changes: Render cards when the rating filter in state is not null.

Surge Deployment Link: https://pr-969-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![peek 2018-07-05 11-00](https://user-images.githubusercontent.com/21009455/42304239-dc5f0fda-8042-11e8-9d80-bf6ef3dec660.gif)
