### PR TITLE
Add message for old IE browsers not supported

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,9 @@
     <title>SUSI Skill CMS</title>
   </head>
   <body>
+    <!--[if lte IE 8]>
+      <p class="unsupported-ie">Browser not supported, please use a newer browser.</p>
+    <![endif]-->
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>


### PR DESCRIPTION
Fixes #950 

Changes: 
- display message "Browser not supported, please use a newer browser." for less than IE 8 versions.

Surge Deployment Link: https://pr-976-fossasia-susi-skill-cms.surge.sh

Screenshots for the change: NA
