### PR TITLE
Prevent text box overflow in bot wizard

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.js
+++ b/src/components/BotBuilder/BotBuilderPages/BuildViews/ConversationView.js
@@ -178,6 +178,12 @@ class ConversationView extends Component {
       <div style={{ padding: '10px 10px 20px 10px' }}>
         <Paper id="message-container" style={styles.paperStyle} zDepth={1}>
           {conversationsData.map(item => {
+            let text = item.name;
+            let messageArr = text.match(/.{1,28}/g);
+            let message = [];
+            for (let i = 0; i < messageArr.length; i++) {
+              message.push(<div>{messageArr[i]}</div>);
+            }
             if (item.type === 'user') {
               return (
                 <div
@@ -188,7 +194,7 @@ class ConversationView extends Component {
                     style={styles.deleteUser}
                     onClick={() => this.handleDeleteNode(item)}
                   />
-                  <div className="user-text-box">{item.name}</div>
+                  <div className="user-text-box">{message}</div>
                   <Person style={{ height: '40px' }} />
                 </div>
               );
@@ -203,7 +209,7 @@ class ConversationView extends Component {
                   alt="bot icon"
                   style={styles.botIcon}
                 />
-                <div className="bot-text-box">{item.name}</div>
+                <div className="bot-text-box">{message}</div>
                 <Delete
                   style={styles.deleteBot}
                   onClick={() => this.handleDeleteNode(item)}


### PR DESCRIPTION
Fixes #964 

Changes: Prevent text box overflow in bot wizard

Surge Deployment Link: https://pr-977-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:

<img width="720" alt="screen shot 2018-07-06 at 12 53 10 am" src="https://user-images.githubusercontent.com/31174685/42343869-1b6933b6-80b8-11e8-9504-adafdf22a149.png">

After:

<img width="661" alt="screen shot 2018-07-06 at 12 53 18 am" src="https://user-images.githubusercontent.com/31174685/42343878-1e8053ea-80b8-11e8-90b0-542274b2bb62.png">

