### PR TITLE
Fixes #970: The category page shows 4 skills per row

### DIFF
--- a/src/components/BrowseSkill/SkillStyle.js
+++ b/src/components/BrowseSkill/SkillStyle.js
@@ -57,7 +57,7 @@ const styles = {
     width: 260,
     height: 170,
     minHeight: '150px',
-    margin: '10px',
+    margin: '10px 0 0 10px',
     overflow: 'hidden',
     justifyContent: 'center',
     fontSize: '10px',

--- a/src/components/SkillCardList/SkillCardList.js
+++ b/src/components/SkillCardList/SkillCardList.js
@@ -149,7 +149,7 @@ class SkillCardList extends Component {
         style={{
           marginTop: '20px',
           marginBottom: '40px',
-          textAlign: 'justify',
+          textAlign: 'center',
           fontSize: '0.1px',
           width: '100%',
         }}


### PR DESCRIPTION
Fixes #970 

Changes: [Add here what changes were made in this issue and if possible provide links.]
* The category page shows 4 skills per row

Surge Deployment Link: https://pr-979-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot from 2018-07-06 02-31-40](https://user-images.githubusercontent.com/12656846/42347896-fbc82398-80c4-11e8-9546-b84d30fc74bf.png)
