### PR TITLE
Add correct image url in botbuilder design

### DIFF
--- a/public/susi-chatbot.js
+++ b/public/susi-chatbot.js
@@ -88,7 +88,7 @@ function applyTheme(){
 	// body background
 	$(".susi-sheet-content-container").css("background-color",botbuilderBackgroundBody);
 	if(botbuilderBodyBackgroundImg){
-		$(".susi-sheet-content-container").css("background-image","url("+botbuilderBodyBackgroundImg+")");
+		$(".susi-sheet-content-container").css("background-image","url('"+botbuilderBodyBackgroundImg+"')");
 	}
 	// user message container
 	$(".susi-comment-by-user .susi-comment-body-container").css("background-color",botbuilderUserMessageBackground);
@@ -101,8 +101,8 @@ function applyTheme(){
 	$(".susi-launcher-button").css("background-color",botbuilderIconColor);
 	$(".susi-comment-avatar").css("background-color",botbuilderIconColor);
 	if(botbuilderIconImg){
-		$(".susi-launcher-button").css("background-image","url("+botbuilderIconImg+")");
-		$(".susi-comment-avatar").css("background-image","url("+botbuilderIconImg+")");
+		$(".susi-launcher-button").css("background-image","url('"+botbuilderIconImg+"')");
+		$(".susi-comment-avatar").css("background-image","url('"+botbuilderIconImg+"')");
 	}
 }
 
@@ -122,7 +122,7 @@ function enableBot() {
 				        '<div id="susi-chatbox" class="susi-chatbox">'+
 				            '<div id="susi-conversation" class="susi-conversation susi-sheet susi-sheet-active susi-active">'+
 				                '<div class="susi-sheet-content">'+
-				                    '<div class="susi-sheet-content-container" style="background-color:'+botbuilderBackgroundBody+'">'+
+				                    '<div class="susi-sheet-content-container" style="background-color:'+botbuilderBackgroundBody+';background-image:url(\''+botbuilderBodyBackgroundImg+'\')">'+
 				                        '<div class="susi-conversation-parts-container">'+
 				                            '<div id="susi-message" class="susi-conversation-parts">'+
 				                            '</div>'+
@@ -151,7 +151,7 @@ function enableBot() {
 			'<div id="susi-launcher-container" class="susi-flex-center susi-avatar-launcher susi-launcher-enabled">'+
 			'<div id="susi-avatar-text">'+'Hey there'+'</div>'+
 			'<div id="susi-launcher" class="susi-launcher susi-flex-center susi-launcher-active" style="background-color: rgb(91, 75, 159);">'+
-			'<div id="susi-launcher-button" class="susi-launcher-button" style="background-image: url('+ botbuilderIconImg +');">'+'</div>'+
+			'<div id="susi-launcher-button" class="susi-launcher-button" style="background-image: url(\''+ botbuilderIconImg +'\');">'+'</div>'+
 			'</div>'+
 			'</div>';
 

--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -16,6 +16,7 @@ import avatars from '../../../Utils/avatars';
 
 const cookies = new Cookies();
 let BASE_URL = urls.API_URL;
+let IMAGE_GET_URL = 'https://api.susi.ai/cms/getImage.png?image=';
 
 class Design extends React.Component {
   constructor(props) {
@@ -100,10 +101,11 @@ class Design extends React.Component {
     $.ajax(settings)
       .done(function(response) {
         response = JSON.parse(response);
+        let img_url = IMAGE_GET_URL + response.image_path;
         self.setState(
           {
             uploadingBodyBackgroundImg: false,
-            botbuilderBodyBackgroundImg: response.image_path,
+            botbuilderBodyBackgroundImg: img_url,
             botbuilderBodyBackgroundImgName: response.image_path.substring(
               response.image_path.indexOf('_') + 1,
             ),
@@ -141,11 +143,12 @@ class Design extends React.Component {
     $.ajax(settings)
       .done(function(response) {
         response = JSON.parse(response);
+        let img_url = IMAGE_GET_URL + response.image_path;
         self.setState(
           {
             uploadingBotbuilderIconImg: false,
             iconSelected: null,
-            botbuilderIconImg: response.image_path,
+            botbuilderIconImg: img_url,
             botbuilderIconImgName: response.image_path.substring(
               response.image_path.indexOf('_') + 1,
             ),


### PR DESCRIPTION
Fixes #978 

Changes: 
- Fix the Image retrieving url by appending `https://api.susi.ai/cms/getImage.png?image=` to the image path.
- Fix bug in `susi-chatbot.js` to correctly display the custom image.

Surge Deployment Link: https://pr-980-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
After uploading custom body background and bot icon images:
![image](https://user-images.githubusercontent.com/17807257/42347961-37252e0e-80c5-11e8-9064-d8b33a489cff.png)

