### PR TITLE
Fixed issues with scrolling through metric cards on different screen sizes

### DIFF
--- a/src/components/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/SkillCardScrollList/SkillCardScrollList.js
@@ -26,6 +26,14 @@ class SkillCardScrollList extends Component {
     this.loadSkillCards();
     this.updateWindowDimensions();
     window.addEventListener('resize', this.updateWindowDimensions);
+
+    let width = window.innerWidth - 304;
+
+    if (window.innerWidth >= 430) {
+      $('.scrolling-wrapper').css({ width: width });
+    } else {
+      $('.scrolling-wrapper').css({ width: window.innerWidth - 46 });
+    }
   };
 
   componentWillUnmount = () => {
@@ -47,10 +55,16 @@ class SkillCardScrollList extends Component {
       default:
         scrollCards = 1;
     }
-
+    let width = window.innerWidth - 304;
     this.setState({
       scrollCards: scrollCards,
     });
+
+    if (window.innerWidth >= 430) {
+      $('.scrolling-wrapper').css({ width: width });
+    } else {
+      $('.scrolling-wrapper').css({ width: window.innerWidth - 46 });
+    }
   };
 
   componentDidUpdate() {


### PR DESCRIPTION
Fixes #946 

Changes: Now horizontal scrolling through the metric cards scrolls up till the last card for all screen sizes.

Surge Deployment Link: https://pr-984-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![metriccardsscrollissues](https://user-images.githubusercontent.com/31135861/42361186-b1092d0c-810a-11e8-93ad-1065dcd1fc80.gif)

Mobile view:
![metriccardsscrollissuesmobile](https://user-images.githubusercontent.com/31135861/42362501-3c5ade4a-8111-11e8-8c9e-f876e35e2cc4.gif)
