### PR TITLE
Fixes #993: Dropdown should not be clickable outside the dropdown area

### DIFF
--- a/src/components/BrowseSkill/SkillStyle.js
+++ b/src/components/BrowseSkill/SkillStyle.js
@@ -89,6 +89,7 @@ const styles = {
   selection: {
     margin: '0px 10px',
     width: '200px',
+    overflowY: 'hidden',
   },
   newSkillBtn: {
     padding: '10px 0px 0px 16px',


### PR DESCRIPTION
Fixes #993 

Changes: Hide the overflow in Y direction, there might still be some pixels below but they appear because of how the component was designed.

Surge Deployment Link: https://pr-995-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/42408155-b1a49608-81e5-11e8-9001-98022183d6cf.png)
