### PR TITLE
update private skill after creating

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -242,6 +242,7 @@ class Build extends Component {
                   sendInfoToProps: this.sendInfoToProps,
                   code: this.state.skillCode,
                   onSkillInfoChange: this.onSkillInfoChange,
+                  onImageChange: this.props.onImageChange,
                 }}
               />
             ) : null}
@@ -268,6 +269,7 @@ class Build extends Component {
 Build.propTypes = {
   code: PropTypes.string,
   sendInfoToProps: PropTypes.func,
+  onImageChange: PropTypes.func,
 };
 
 export default Build;

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -448,6 +448,9 @@ export default class CreateSkill extends React.Component {
 
   _onChange = event => {
     // Assuming only image
+    if (this.props.botBuilder) {
+      this.props.botBuilder.onImageChange();
+    }
     let file = this.file.files[0];
     if (event.target.files && event.target.files[0]) {
       let reader = new FileReader();


### PR DESCRIPTION
Fixes #991 

Changes: 
- Change "Save" button to "Update" button after saving the skill first time
- Make request to `modifySkill.json` API with appropriate parameters for modifying the skill

This is only the client side for now. The server related issue is [#948](https://github.com/fossasia/susi_server/issues/948) and I am working on it. Thus it would be fully functional once the server part is over.

Surge Deployment Link: https://pr-1010-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
"Save" button being changed to "Update" button after saving the skill first time:
![image](https://user-images.githubusercontent.com/17807257/42427132-7854dc8a-834a-11e8-89e4-47409d16cf0e.png)

modifySkill API being called after updating the skill:
![image](https://user-images.githubusercontent.com/17807257/42427036-ee61c3bc-8349-11e8-8010-39e0321ff6ca.png)
