### PR TITLE
Fixes #1011: Make the footer stick to the bottom of the page

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -376,7 +376,7 @@ export default class BrowseSkill extends React.Component {
     }
 
     return (
-      <div>
+      <div style={styles.browseSkillRoot}>
         <StaticAppBar
           {...this.props}
           zDepth={1}

--- a/src/components/BrowseSkill/SkillStyle.js
+++ b/src/components/BrowseSkill/SkillStyle.js
@@ -3,6 +3,7 @@ const styles = {
     display: 'flex',
     flexDirection: 'row',
     overflowX: 'hidden',
+    flex: '1 0 auto',
   },
   center: {
     display: 'flex',
@@ -181,6 +182,11 @@ const styles = {
     fontSize: 16,
     marginTop: 24,
     padding: 16,
+  },
+  browseSkillRoot: {
+    height: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
   },
 };
 


### PR DESCRIPTION
Fixes #1011 

Changes: Make the footer stick to the bottom of the page, try zooming out as much as you want, footer will always be at the end.

Surge Deployment Link: https://pr-1017-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/42432885-6b1303ce-836a-11e8-829f-1d313ad62515.png)
