### PR TITLE
Check for user's name existence before assigning

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -110,7 +110,10 @@ class StaticAppBar extends Component {
         jsonp: 'callback',
         crossDomain: true,
         success: function(data) {
-          let userName = data.settings.userName;
+          let userName = '';
+          if (data.settings && data.settings.userName) {
+            userName = data.settings.userName;
+          }
           cookies.set('username', userName, {
             path: '/',
             domain: '.susi.ai',


### PR DESCRIPTION
Fixes #1026 

Changes: 
- check if the user's name is set or not before assigning. This was causing an error for users whose name were not set.

Surge Deployment Link: https://pr-1027-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
before (the page throws error):
![image](https://user-images.githubusercontent.com/17807257/42450730-bf194bb2-83a2-11e8-82f9-213183a0e73b.png)
after (the page doesn't throw an error and displays the user email instead):
![image](https://user-images.githubusercontent.com/17807257/42450759-d9459b08-83a2-11e8-9975-b21e6bd116cc.png)


