### PR TITLE
Fixes reRender of geoCharts #1033

### DIFF
--- a/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.js
+++ b/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.js
@@ -1,9 +1,9 @@
 // Packages
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { GeoChart } from 'react-chartkick';
 
-class CountryWiseSkillUsageCard extends Component {
+class CountryWiseSkillUsageCard extends PureComponent {
   render() {
     return (
       <div>


### PR DESCRIPTION
Fixes #1033

**Changes**: The render of charts takes time, using pureComponents, (React knows the props that are sent into a component), it can be deterministic in knowing if it has to reRender or not.

Surge Deployment Link: https://pr-1033-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

![fix-geochart](https://user-images.githubusercontent.com/18073126/42470149-37258d8a-83d7-11e8-909a-29884fe8918c.gif)
