### PR TITLE
display update button after private skill is saved

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -411,32 +411,35 @@ class BotWizard extends React.Component {
                   <Link to="/botbuilder">
                     <RaisedButton label="Cancel" />
                   </Link>
-                  <RaisedButton
-                    label={
-                      this.state.savingSkill ? (
-                        <CircularProgress color="#ffffff" size={32} />
-                      ) : (
-                        'Save'
-                      )
-                    }
-                    backgroundColor={colors.header}
-                    labelColor="#fff"
-                    style={{ marginLeft: 10 }}
-                    onTouchTap={this.saveClick}
-                  />
-                  <RaisedButton
-                    label={
-                      this.state.savingSkill ? (
-                        <CircularProgress color="#ffffff" size={32} />
-                      ) : (
-                        'Update'
-                      )
-                    }
-                    backgroundColor={colors.header}
-                    labelColor="#fff"
-                    style={{ marginLeft: 10 }}
-                    onTouchTap={this.saveClick}
-                  />
+                  {this.state.updateSkillNow ? (
+                    <RaisedButton
+                      label={
+                        this.state.savingSkill ? (
+                          <CircularProgress color="#ffffff" size={32} />
+                        ) : (
+                          'Update'
+                        )
+                      }
+                      backgroundColor={colors.header}
+                      labelColor="#fff"
+                      style={{ marginLeft: 10 }}
+                      onTouchTap={this.saveClick}
+                    />
+                  ) : (
+                    <RaisedButton
+                      label={
+                        this.state.savingSkill ? (
+                          <CircularProgress color="#ffffff" size={32} />
+                        ) : (
+                          'Save'
+                        )
+                      }
+                      backgroundColor={colors.header}
+                      labelColor="#fff"
+                      style={{ marginLeft: 10 }}
+                      onTouchTap={this.saveClick}
+                    />
+                  )}
                 </Paper>
               </Col>
 


### PR DESCRIPTION
Fixes #1042 

Changes: 
- show "Save" button first time when the user should save the skill
- show "Update" button after the skill has been saved first time

Surge Deployment Link: https://pr-1044-fossasia-susi-skill-cms.surge.sh
Note: the login on surge is not working currently (see issue https://github.com/fossasia/susi_skill_cms/issues/1041).
Screenshots for the change:
first time (before saving):
![image](https://user-images.githubusercontent.com/17807257/42506015-3d1dd670-845e-11e8-921b-c35fa56953d2.png)
after saving first time:
![image](https://user-images.githubusercontent.com/17807257/42506054-563a1c9a-845e-11e8-971b-84300c7a3557.png)
