### PR TITLE
Fix bug with blank entries in configure tab

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Configure.js
+++ b/src/components/BotBuilder/BotBuilderPages/Configure.js
@@ -140,26 +140,28 @@ class Configure extends Component {
             </TableHeader>
             <TableBody displayRowCheckbox={false}>
               {configData.map((item, index) => {
-                return (
-                  <TableRow key={index}>
-                    <TableRowColumn style={{ fontSize: '16px' }}>
-                      {item.name}
-                    </TableRowColumn>
-                    <TableRowColumn style={{ fontSize: '16px' }}>
-                      {item.last}
-                    </TableRowColumn>
-                    <TableRowColumn>
-                      <SelectField
-                        floatingLabelText="Status"
-                        fullWidth={true}
-                        value={item.status}
-                      >
-                        <MenuItem value={1} primaryText="Enable" />
-                        <MenuItem value={2} primaryText="Disable" />
-                      </SelectField>
-                    </TableRowColumn>
-                  </TableRow>
-                );
+                if (item.name) {
+                  return (
+                    <TableRow key={index}>
+                      <TableRowColumn style={{ fontSize: '16px' }}>
+                        {item.name}
+                      </TableRowColumn>
+                      <TableRowColumn style={{ fontSize: '16px' }}>
+                        {item.last}
+                      </TableRowColumn>
+                      <TableRowColumn>
+                        <SelectField
+                          floatingLabelText="Status"
+                          fullWidth={true}
+                          value={item.status}
+                        >
+                          <MenuItem value={1} primaryText="Enable" />
+                          <MenuItem value={2} primaryText="Disable" />
+                        </SelectField>
+                      </TableRowColumn>
+                    </TableRow>
+                  );
+                }
               })}
               <TableRow />
             </TableBody>


### PR DESCRIPTION
Fixes #1043 

Changes: Fixed bug with blank entries showing up in configure tab

Surge Deployment Link: https://pr-1045-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
<img width="851" alt="screen shot 2018-07-10 at 12 57 26 pm" src="https://user-images.githubusercontent.com/31174685/42495560-0a1db208-8441-11e8-9013-43aa38efc117.png">

Now:
<img width="730" alt="screen shot 2018-07-10 at 5 37 58 pm" src="https://user-images.githubusercontent.com/31174685/42508973-095f06e2-8468-11e8-832e-040cc6f50f63.png">

