### PR TITLE
Fixes #1025: Update styling of `back to SUSI skills` on sidebar

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -544,7 +544,13 @@ export default class BrowseSkill extends React.Component {
                   <Link to="/">
                     <div className="index-link-sidebar">{'< SUSI Skills'}</div>
                   </Link>
-                  <div style={{ marginLeft: '10px', fontWeight: 'bold' }}>
+                  <div
+                    style={{
+                      marginLeft: '10px',
+                      fontWeight: 'bold',
+                      fontSize: '15px',
+                    }}
+                  >
                     {this.props.routeValue}
                   </div>
                 </div>

--- a/src/components/BrowseSkill/custom.css
+++ b/src/components/BrowseSkill/custom.css
@@ -11,9 +11,10 @@ div.scrolling-wrapper::-webkit-scrollbar {
 }
 
 .index-link-sidebar {
-    font-size: 15px;
+    color: rgba(0, 0, 0, 0.54);
+    font-size: 16px;
+    font-weight: bold;
     width: fit-content;
-    color: black;   
 }
 
 .index-link-sidebar:hover {


### PR DESCRIPTION
Fixes #1025

Changes: Updated the styling of `< SUSI Skills` as per our theme.

Surge Deployment Link: https://pr-1047-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/42511275-07978558-846f-11e8-816a-344436696719.png)
