### PR TITLE
Make Dashboard heading similar to other headings

### DIFF
--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -35,7 +35,9 @@ class Dashboard extends React.Component {
         <div style={styles.home} className="botbuilder-page-wrapper">
           <br />
           <br />
-          <h1 className="center">My Dashboard</h1>
+          <h1 className="center" style={{ color: 'black' }}>
+            My Dashboard
+          </h1>
           <br />
           <Paper
             style={styles.paperStyle}


### PR DESCRIPTION
Fixes #1051 

Changes: Made dashboard heading similar to other headings

Surge Deployment Link: https://pr-1052-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
<img width="228" alt="screen shot 2018-07-10 at 10 47 49 pm" src="https://user-images.githubusercontent.com/31174685/42526782-762dd83a-8494-11e8-9243-e16249c77c8d.png">

Now:
<img width="195" alt="screen shot 2018-07-10 at 10 54 20 pm" src="https://user-images.githubusercontent.com/31174685/42526787-782f6054-8494-11e8-8142-2011308f97c9.png">

