### PR TITLE
Make current view icon of build menu disabled

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -206,6 +206,7 @@ class Build extends Component {
                     treeView: false,
                   });
                 }}
+                disabled={this.state.codeView}
               >
                 <Code />
               </IconButton>
@@ -218,6 +219,7 @@ class Build extends Component {
                     treeView: false,
                   });
                 }}
+                disabled={this.state.conversationView}
               >
                 <QA />
               </IconButton>
@@ -230,6 +232,7 @@ class Build extends Component {
                     treeView: true,
                   });
                 }}
+                disabled={this.state.treeView}
               >
                 <Timeline />
               </IconButton>


### PR DESCRIPTION
Fixes #1015 

Changes: Earlier all the icons looked same irrespective of which view the user was on. Now the current view icon is disabled to make is distinct.

Surge Deployment Link: https://pr-1053-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
![jul-10-2018 23-04-21](https://user-images.githubusercontent.com/31174685/42527265-c7b91ba0-8495-11e8-9f4e-2b0215af4b99.gif)

Now:
![jul-10-2018 23-05-21](https://user-images.githubusercontent.com/31174685/42527275-cbb38a06-8495-11e8-816b-53cf97b9441b.gif)

