### PR TITLE
Fixes #1059: New arrivals subheader not visible on selecting any time filter

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -492,10 +492,7 @@ export default class BrowseSkill extends React.Component {
               </IconMenu>
             </div>
             <Menu desktop={true} disableAutoFocus={true}>
-              <Subheader style={{ fontWeight: 'bold', fontSize: '16px' }}>
-                New Arrivals
-              </Subheader>
-              {this.state.timeFilter && (
+              {this.state.timeFilter ? (
                 <div className="category-sidebar-section">
                   <div
                     className="index-link-sidebar"
@@ -513,6 +510,10 @@ export default class BrowseSkill extends React.Component {
                     {`Last ${this.state.timeFilter} Days`}
                   </div>
                 </div>
+              ) : (
+                <Subheader style={{ fontWeight: 'bold', fontSize: '16px' }}>
+                  New Arrivals
+                </Subheader>
               )}
               {!this.state.timeFilter && (
                 <MenuItem


### PR DESCRIPTION
Fixes #1059 

Changes: Display `New Arrivals` subheader only when No time filter is applied

Surge Deployment Link: https://pr-1062-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/42553674-661de668-84ff-11e8-8ee9-0f2c166bd725.png)
