### PR TITLE
Fixed the popover position of the burger menu

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -57,7 +57,6 @@ class StaticAppBar extends Component {
       showOptions: false,
       showAdmin: false,
       anchorEl: null,
-      leftGap: '0px',
     };
   }
 
@@ -169,12 +168,6 @@ class StaticAppBar extends Component {
   }
 
   showOptions = event => {
-    var p = $('#rightIconButton').width();
-    var screenWidth = $(window).width();
-    this.setState({
-      leftGap:
-        (screenWidth - p) / 2 + p - (cookies.get('loggedIn') ? 170 : 130),
-    });
     event.preventDefault();
     this.setState({
       showOptions: true,
@@ -237,7 +230,6 @@ class StaticAppBar extends Component {
       top: '10px',
       cursor: 'pointer',
     };
-    var leftGap = this.state.leftGap;
 
     const bodyStyle = {
       padding: 0,
@@ -284,7 +276,7 @@ class StaticAppBar extends Component {
               float: 'right',
               position: 'relative',
               marginTop: '46px',
-              marginLeft: leftGap,
+              marginRight: '8px',
             }}
             open={this.state.showOptions}
             anchorEl={this.state.anchorEl}


### PR DESCRIPTION
Fixes #1064 

Changes: Fixed the popover position of the burger menu by providing it with some margin on the right, similar to how it is done on https://accounts.susi.ai.

Surge Deployment Link: https://pr-1065-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
<img width="243" alt="screen shot 2018-07-11 at 2 59 33 pm" src="https://user-images.githubusercontent.com/31135861/42563111-0d7aa9d0-851b-11e8-941d-6e84496c3128.png">

After:
<img width="218" alt="screen shot 2018-07-11 at 2 57 37 pm" src="https://user-images.githubusercontent.com/31135861/42563120-1502444c-851b-11e8-9b58-841e944b66a8.png">
