### PR TITLE
Moved Admin below About in burger menu

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -292,13 +292,6 @@ class StaticAppBar extends Component {
             targetOrigin={{ horizontal: 'right', vertical: 'top' }}
             onRequestClose={this.closeOptions}
           >
-            {this.state.showAdmin === true ? (
-              <MenuItem
-                primaryText="Admin"
-                containerElement={<Link to="/admin" />}
-                rightIcon={<List />}
-              />
-            ) : null}
             {cookies.get('loggedIn') ? (
               <MenuItem
                 primaryText="Dashboard"
@@ -329,6 +322,13 @@ class StaticAppBar extends Component {
               >
                 About
               </MenuItem>
+            ) : null}
+            {this.state.showAdmin === true ? (
+              <MenuItem
+                primaryText="Admin"
+                containerElement={<Link to="/admin" />}
+                rightIcon={<List />}
+              />
             ) : null}
             {cookies.get('loggedIn') ? (
               <MenuItem


### PR DESCRIPTION
Fixes #1069 

Changes: Moved `Admin` below `About` in the burger menu.

Surge Deployment Link: https://pr-1070-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
<img width="168" alt="screen shot 2018-07-11 at 6 06 13 pm" src="https://user-images.githubusercontent.com/31135861/42571691-6a5a34f8-8535-11e8-8202-dec6d5db4642.png">

