### PR TITLE
Corrected the hover color of some links on sidebar

### DIFF
--- a/src/components/BrowseSkill/custom.css
+++ b/src/components/BrowseSkill/custom.css
@@ -18,7 +18,7 @@ div.scrolling-wrapper::-webkit-scrollbar {
 }
 
 .index-link-sidebar:hover {
-    color: #284779;
+    color: #4285f4;
     cursor: pointer;
 }
 


### PR DESCRIPTION
Fixes #1048 

Changes: Corrected the hover color of `< SUSI Skills` and `< Any release` on the sidebar.

Surge Deployment Link: https://pr-1072-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
<img width="131" alt="screen shot 2018-07-10 at 8 23 27 pm" src="https://user-images.githubusercontent.com/31135861/42612585-bbadc390-85b9-11e8-98c6-5ff3be75907b.png">

After:
<img width="134" alt="screen shot 2018-07-12 at 9 55 49 am" src="https://user-images.githubusercontent.com/31135861/42612592-c8dbe3da-85b9-11e8-981b-facdcd71e669.png">

