### PR TITLE
Update old skill only if the skill is modified successfully

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -244,20 +244,20 @@ class BotWizard extends React.Component {
 
     $.ajax(settings)
       .done(function(response) {
-        let savedSkillOld = {
-          OldGroup: self.state.groupValue,
-          OldLanguage: self.state.languageValue,
-          OldSkill: self.state.expertValue.trim().replace(/\s/g, '_'),
-          old_image_name: self.state.imageUrl.replace('images/', ''),
-        };
-        self.setState({
-          savingSkill: false,
-          savedSkillOld,
-          updateSkillNow: true,
-          imageChanged: false,
-        });
         let data = JSON.parse(response);
         if (data.accepted === true) {
+          let savedSkillOld = {
+            OldGroup: self.state.groupValue,
+            OldLanguage: self.state.languageValue,
+            OldSkill: self.state.expertValue.trim().replace(/\s/g, '_'),
+            old_image_name: self.state.imageUrl.replace('images/', ''),
+          };
+          self.setState({
+            savingSkill: false,
+            savedSkillOld,
+            updateSkillNow: true,
+            imageChanged: false,
+          });
           notification.open({
             message: 'Accepted',
             description: 'Your Skill has been saved',


### PR DESCRIPTION
Fixes #1074 

Changes: - Check if the server has accepted the modified skill or not. If it has modified then only update the old skill details. Previously it was updating the skill details even if the server sends an unsuccessful response. This was preventing the user from updating the skill further.

Surge Deployment Link: https://pr-1075-fossasia-susi-skill-cms.surge.sh

Screenshots for the change: NA
