### PR TITLE
Show only non empty languages

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -187,28 +187,30 @@ export default class BrowseSkill extends React.Component {
   };
 
   loadLanguages = () => {
-    if (this.state.languages.length === 0) {
-      $.ajax({
-        url: urls.API_URL + '/cms/getAllLanguages.json',
-        dataType: 'jsonp',
-        jsonp: 'callback',
-        crossDomain: true,
-        success: function(data) {
-          data = data.languagesArray;
-          if (data) {
-            data.sort();
-            this.setState({ languages: data });
-            languages = [];
-            for (let i = 0; i < data.length; i++) {
-              languages.push(data[i]);
-            }
-          }
-        }.bind(this),
-        error: function(e) {
-          console.log('Error while fetching languages', e);
-        },
-      });
+    let url = urls.API_URL + '/cms/getAllLanguages.json?';
+    if (this.state.groupValue != null) {
+      url += 'group=' + this.state.groupValue;
     }
+    $.ajax({
+      url: url,
+      dataType: 'jsonp',
+      jsonp: 'callback',
+      crossDomain: true,
+      success: function(data) {
+        data = data.languagesArray;
+        if (data) {
+          data.sort();
+          languages = [];
+          for (let i = 0; i < data.length; i++) {
+            languages.push(data[i]);
+          }
+          this.setState({ languages: data });
+        }
+      }.bind(this),
+      error: function(e) {
+        console.log('Error while fetching languages', e);
+      },
+    });
   };
 
   loadCards = () => {
@@ -274,12 +276,17 @@ export default class BrowseSkill extends React.Component {
             self.state.ratingRefine,
           );
         }
-        self.setState({
-          skills: data.filteredData,
-          // cards: cards,
-          skillURL: url,
-          skillsLoaded: true,
-        });
+        self.setState(
+          {
+            skills: data.filteredData,
+            // cards: cards,
+            skillURL: url,
+            skillsLoaded: true,
+          },
+          function() {
+            this.loadLanguages();
+          },
+        );
         // console.log(self.state)
       },
       error: function(e) {


### PR DESCRIPTION
Fixes #1054 
Merge the server side PR before it : https://github.com/fossasia/susi_server/pull/955

Changes: 
Show only those languages in the category page for which skills are available.

Surge Deployment Link: https://susi--cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/10573038/42620021-65c75be4-85d7-11e8-9b6d-e77d6228a028.png)
