### PR TITLE
Fixes #1029: Examples utilizes entire space of skill card

### DIFF
--- a/src/components/SkillCardScrollList/ScrollStyle.js
+++ b/src/components/SkillCardScrollList/ScrollStyle.js
@@ -41,6 +41,7 @@ const styles = {
     height: '20px',
   },
   example: {
+    whiteSpace: 'normal',
     textAlign: 'center',
     fontStyle: 'italic',
     fontSize: '14px',


### PR DESCRIPTION
Fixes #1029

Changes: [Add here what changes were made in this issue and if possible provide links.]
* Show the entire example text.

Surge Deployment Link: https://pr-1080-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![deepinscreenshot_select-area_20180712160145](https://user-images.githubusercontent.com/12656846/42628180-e863e436-85ec-11e8-86ff-ec574b0b7779.png)
