### PR TITLE
Center aligned the loading animation while navigating on the CMS homepage

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -794,7 +794,7 @@ export default class BrowseSkill extends React.Component {
             {!this.state.skillsLoaded && (
               <div>
                 <h1 style={styles.loader}>
-                  <div>
+                  <div className="center">
                     <CircularProgress size={62} color="#4285f5" />
                     <h4>Loading</h4>
                   </div>


### PR DESCRIPTION
Fixes #1083

Changes: Center aligned the loading animation while navigating on the CMS homepage.

Surge Deployment Link: https://pr-1084-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
<img width="1440" alt="screen shot 2018-07-13 at 3 01 49 am" src="https://user-images.githubusercontent.com/31135861/42671465-b73b62f8-867d-11e8-8b43-d9b7c180204b.png">


After:
<img width="1440" alt="screen shot 2018-07-13 at 9 18 44 am" src="https://user-images.githubusercontent.com/31135861/42671474-c346a12a-867d-11e8-9dda-48d9b93c1805.png">
