### PR TITLE
UI improvements on Admin tab

### DIFF
--- a/src/components/Admin/Admin.css
+++ b/src/components/Admin/Admin.css
@@ -27,8 +27,22 @@
     margin-left: 21px;
 }
 
+.h2{
+    padding-top: 65px;
+    font-size: 35px;
+    margin-left: 23px;
+}
+
 .containerPaper{
     margin-top: -68px;
     margin-left: 60px;
     margin-right: 40px;
+}
+
+.ant-tabs-tab-prev {
+    display: none;
+}
+
+.ant-tabs-tab-next {
+    display: none;
 }

--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -68,11 +68,15 @@ class Admin extends Component {
           <div>
             <div className="heading">
               <StaticAppBar {...this.props} />
-              <h1 className="h1">SUSI.AI Admin Panel</h1>
+              <h2 className="h2">Admin Panel</h2>
             </div>
             <div className="tabs">
               <Paper style={styles.tabStyle} zDepth={0}>
-                <Tabs tabPosition={this.state.tabPosition} animated={false}>
+                <Tabs
+                  tabPosition={this.state.tabPosition}
+                  animated={false}
+                  type="card"
+                >
                   <TabPane tab="Admin" key="1">
                     Tab for Admin Content
                   </TabPane>


### PR DESCRIPTION
Fixes #1090

Changes: 
- Moved the position of tabs to the left.
- Changed heading style.
- Tabs are now in card form.

For testing: http://hopeless-orange.surge.sh/. Choose `Admin` from the dropdown hamburger menu to access admin tab. (Logging in is not required) 

Screenshots for the change:

Before:
<img width="1055" alt="screen shot 2018-07-13 at 2 22 15 pm" src="https://user-images.githubusercontent.com/31174685/42682432-3a60f01a-86a8-11e8-87af-60b52ad4d94a.png">

After:
<img width="1059" alt="screen shot 2018-07-13 at 2 16 31 pm" src="https://user-images.githubusercontent.com/31174685/42682438-3d616420-86a8-11e8-8943-c071b74342f9.png">

