### PR TITLE
Fixed issues with links to Skill Details page in List View

### DIFF
--- a/src/components/SkillCardList/SkillCardList.js
+++ b/src/components/SkillCardList/SkillCardList.js
@@ -76,26 +76,27 @@ class SkillCardList extends Component {
           </div>
           <div style={styles.content}>
             <div style={styles.header}>
-              <Link
-                key={el}
-                to={{
-                  pathname: `/${skill.group}/${skill.skill_tag}/${
-                    this.props.languageValue
-                  }`,
-                  state: {
-                    url: this.props.skillUrl,
-                    element: el,
-                    name: el,
-                    modelValue: this.props.modelValue,
-                    groupValue: skill.group,
-                    languageValue: this.props.languageValue,
-                  },
-                }}
-              >
-                <div style={styles.title}>
+              <div style={styles.title}>
+                <Link
+                  key={el}
+                  to={{
+                    pathname: `/${skill.group}/${skill.skill_tag}/${
+                      this.props.languageValue
+                    }`,
+                    state: {
+                      url: this.props.skillUrl,
+                      element: el,
+                      name: el,
+                      modelValue: this.props.modelValue,
+                      groupValue: skill.group,
+                      languageValue: this.props.languageValue,
+                    },
+                  }}
+                >
                   <span>{skill_name}</span>
-                </div>
-              </Link>
+                </Link>
+              </div>
+
               <div style={styles.authorName}>
                 <span>{author_name}</span>
               </div>


### PR DESCRIPTION
Fixes #1121 

Changes: Fixed issues with links to Skill Details page in List View

Surge Deployment Link: https://pr-1133-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
<img width="1440" alt="linkissueslistview" src="https://user-images.githubusercontent.com/31135861/42735164-fa70f470-886c-11e8-9fd2-c6c5d9e3cbbe.png">

Now, clicking on only the text in the highlighted area in the above screenshot take us to the corresponding Skill details page.