### PR TITLE
Implement feature to edit chatbot after creating it

### DIFF
--- a/src/components/BotBuilder/BotBuilder.js
+++ b/src/components/BotBuilder/BotBuilder.js
@@ -61,15 +61,26 @@ class BotBuilder extends React.Component {
     });
     bots.map(bot => {
       chatbots.push(
-        <Card className="bot-template-card">
-          <RaisedButton
-            label={bot.name}
-            labelPosition="before"
-            labelStyle={{ verticalAlign: 'middle' }}
-            backgroundColor={colors.header}
-            labelColor="#fff"
-          />
-        </Card>,
+        <Link
+          to={
+            '/botbuilder/botwizard?name=' +
+            bot.name +
+            '&language=' +
+            bot.language +
+            '&group=' +
+            bot.group
+          }
+        >
+          <Card className="bot-template-card">
+            <RaisedButton
+              label={bot.name}
+              labelPosition="before"
+              labelStyle={{ verticalAlign: 'middle' }}
+              backgroundColor={colors.header}
+              labelColor="#fff"
+            />
+          </Card>
+        </Link>,
       );
     });
     this.setState({

--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -12,8 +12,21 @@ class Build extends Component {
     super(props);
     let skillCode =
       '::name <Skill_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query';
+    let skillCategory, skillLanguage, skillName;
     if (this.props.code) {
       skillCode = this.props.code;
+      skillCategory = skillCode
+        .split('::category ')[1]
+        .split('::')[0]
+        .trim();
+      skillLanguage = skillCode
+        .split('::language ')[1]
+        .split('::')[0]
+        .trim();
+      skillName = skillCode
+        .split('::name ')[1]
+        .split('::')[0]
+        .trim();
     }
     this.state = {
       treeData: {
@@ -25,6 +38,9 @@ class Build extends Component {
         botResponses: [],
       },
       skillCode,
+      skillCategory,
+      skillLanguage,
+      skillName,
       codeView: true,
       conversationView: false,
       treeView: false,
@@ -246,6 +262,9 @@ class Build extends Component {
                 botBuilder={{
                   sendInfoToProps: this.sendInfoToProps,
                   code: this.state.skillCode,
+                  name: this.state.skillName,
+                  category: this.state.skillCategory,
+                  language: this.state.skillLanguage,
                   onSkillInfoChange: this.onSkillInfoChange,
                   onImageChange: this.props.onImageChange,
                 }}

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -41,7 +41,29 @@ export default class CreateSkill extends React.Component {
     self.loadgroups();
     // send code to CodeView in botbuilder
     if (this.props.botBuilder) {
-      this.setState({ code: this.props.botBuilder.code });
+      this.setState({
+        code: this.props.botBuilder.code,
+      });
+      if (
+        this.props.botBuilder.category &&
+        this.props.botBuilder.language &&
+        this.props.botBuilder.name
+      ) {
+        // set group, language and name while editing a saved bot
+        this.setState(
+          {
+            groupValue: this.props.botBuilder.category,
+            languageValue: this.props.botBuilder.language,
+            expertValue: this.props.botBuilder.name,
+            imageUrl: '',
+            showImage: true,
+            groupSelect: false,
+            languageSelect: false,
+            expertSelect: false,
+          },
+          () => this.handleGroupChange(null, 0, this.props.botBuilder.category),
+        );
+      }
     }
   }
 
@@ -477,7 +499,6 @@ export default class CreateSkill extends React.Component {
       },
       () => this.sendInfoToProps(),
     );
-    // console.log(this.state.imageUrl);
     const pattern = /^::image\s(.*)$/m;
     const code = this.state.code.replace(pattern, `::image images/${imgUrl}`);
     this.setState({


### PR DESCRIPTION
Partially fixes issue #1120 

Changes: The code for a saved bot is fetched from the server and then user is able to edit it.

**IMPORTANT NOTE:**
Currently we're not storing the URLs of images, hence can't be fetched from the server, hence can not be displayed while editing. Due to this, currently user can not update a saved chatbot because it can not be done without an image. Storage of image url needs to be implemented in the server and then we have to do it in skills cms which will complete this feature. Hence currently, this can be merged as a work in progress. Issue in server: https://github.com/fossasia/susi_server/issues/998
Also, after PR #1115 , the design code format was changed. Hence, this will not work with chatbots saved with old design format. So, in order to test it, please create a new chatbot and then click on it in "My Bots" section.
Thanks!

Surge Deployment Link: https://pr-1137-fossasia-susi-skill-cms.surge.sh

![jul-17-2018 16-52-04](https://user-images.githubusercontent.com/31174685/42814684-9ad16e88-89e2-11e8-9aba-2fc88b931bbb.gif)

