### PR TITLE
Improve UI For Skill Card and misc fixes#1129

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -753,7 +753,7 @@ export default class BrowseSkill extends React.Component {
                     label="List view"
                     labelStyle={{ display: 'none' }}
                     checkedIcon={
-                      <ActionViewStream style={{ color: '#4285f4' }} />
+                      <ActionViewStream style={{ fill: '#4285f4' }} />
                     }
                     uncheckedIcon={<ActionViewStream />}
                   />
@@ -762,7 +762,7 @@ export default class BrowseSkill extends React.Component {
                     label="Grid view"
                     labelStyle={{ display: 'none' }}
                     checkedIcon={
-                      <ActionViewModule style={{ color: '#4285f4' }} />
+                      <ActionViewModule style={{ fill: '#4285f4' }} />
                     }
                     uncheckedIcon={<ActionViewModule />}
                   />

--- a/src/components/BrowseSkill/SkillStyle.js
+++ b/src/components/BrowseSkill/SkillStyle.js
@@ -91,6 +91,7 @@ const styles = {
     margin: '0px 10px',
     width: '200px',
     overflowY: 'hidden',
+    fontSize: '14px',
   },
   newSkillBtn: {
     padding: '10px 0px 0px 16px',

--- a/src/components/SkillCardList/SkillCardList.js
+++ b/src/components/SkillCardList/SkillCardList.js
@@ -93,7 +93,7 @@ function createListCard(
                 }`,
               }}
             >
-              <img alt={skill_name} src={image} style={styles.image} />
+              <img alt={skillName} src={image} style={styles.image} />
             </Link>
           </div>
         ) : (

--- a/src/components/SkillCardList/SkillCardList.js
+++ b/src/components/SkillCardList/SkillCardList.js
@@ -5,6 +5,167 @@ import PropTypes from 'prop-types';
 import CircleImage from '../CircleImage/CircleImage';
 import styles from './SkillCardStyle';
 
+function createListCard(
+  el,
+  skillName,
+  skillUrl,
+  authorName,
+  description,
+  image,
+  language,
+  skill,
+  examples,
+  totalRating,
+  averageRating,
+) {
+  const mobileView = window.innerWidth < 430;
+  if (mobileView) {
+    return (
+      <div style={styles.skillCard} key={el}>
+        <div style={styles.imageContainerMobile}>
+          {image ? (
+            <div style={styles.imageMobile}>
+              <img alt={skillName} src={image} style={styles.imageMobile} />
+            </div>
+          ) : (
+            <CircleImage name={skillName} size="96" />
+          )}
+        </div>
+        <div style={styles.content}>
+          <div style={styles.header}>
+            <div style={styles.title}>
+              <Link
+                key={el}
+                to={{
+                  pathname: `/${skill.group}/${skill.skill_tag}/${language}`,
+                  state: {
+                    url: skillUrl,
+                    element: el,
+                    name: el,
+                    modelValue: skill.model,
+                    groupValue: skill.group,
+                    languageValue: language,
+                  },
+                }}
+              >
+                <span>{skillName}</span>
+              </Link>
+            </div>
+            <div style={styles.authorName}>
+              <span>{authorName}</span>
+            </div>
+            <div style={{ lineHeight: 1.35, fontSize: 16 }}>
+              <span>Skills for Alexa</span>
+            </div>
+            <div style={styles.rating}>
+              <Ratings
+                style={{ display: 'flex' }}
+                rating={averageRating || 0}
+                widgetRatedColors="#ffbb28"
+                widgetDimensions="20px"
+                widgetSpacings="0px"
+              >
+                <Ratings.Widget />
+                <Ratings.Widget />
+                <Ratings.Widget />
+                <Ratings.Widget />
+                <Ratings.Widget />
+              </Ratings>
+              <span style={styles.totalRating} title="Total ratings">
+                {totalRating || 0}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div style={styles.skillCard} key={el}>
+      <div style={styles.imageContainer}>
+        {image ? (
+          <div style={styles.image}>
+            <Link
+              key={el}
+              to={{
+                pathname: `/${skill.group}/${skill.skill_tag}/${
+                  this.props.languageValue
+                }`,
+              }}
+            >
+              <img alt={skill_name} src={image} style={styles.image} />
+            </Link>
+          </div>
+        ) : (
+          <CircleImage name={skillName} size="160" />
+        )}
+      </div>
+      <div style={styles.content}>
+        <div style={styles.header}>
+          <div style={styles.title}>
+            <Link
+              key={el}
+              to={{
+                pathname: `/${skill.group}/${skill.skill_tag}/${language}`,
+                state: {
+                  url: skillUrl,
+                  element: el,
+                  name: el,
+                  modelValue: skill.model,
+                  groupValue: skill.group,
+                  languageValue: language,
+                },
+              }}
+            >
+              <span>{skillName}</span>
+            </Link>
+          </div>
+          <div style={styles.authorName}>
+            <span>{authorName}</span>
+          </div>
+        </div>
+        <div style={styles.details}>
+          <div style={styles.exampleSection}>
+            {examples.map((eg, index) => {
+              return (
+                <div key={index} style={styles.example}>
+                  &quot;{eg}&quot;
+                </div>
+              );
+            })}
+          </div>
+          <div style={styles.textData}>
+            <div style={styles.row}>
+              <div style={styles.rating}>
+                <Ratings
+                  style={{ display: 'flex' }}
+                  rating={averageRating || 0}
+                  widgetRatedColors="#ffbb28"
+                  widgetDimensions="20px"
+                  widgetSpacings="0px"
+                >
+                  <Ratings.Widget />
+                  <Ratings.Widget />
+                  <Ratings.Widget />
+                  <Ratings.Widget />
+                  <Ratings.Widget />
+                </Ratings>
+                <span style={styles.totalRating} title="Total ratings">
+                  {totalRating || 0}
+                </span>
+              </div>
+            </div>
+            <div style={styles.row}>
+              <div style={styles.descriptionTitle}>Description</div>
+              <div style={styles.description}>{description}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 class SkillCardList extends Component {
   constructor(props) {
     super(props);
@@ -33,16 +194,17 @@ class SkillCardList extends Component {
     let cards = [];
     Object.keys(this.state.skills).forEach(el => {
       let skill = this.state.skills[el];
-      let skill_name = 'Name not available',
+      let skillName = 'Name not available',
         examples = [],
         image = '',
         description = 'No description available',
-        author_name = 'Author',
-        average_rating = 0,
-        total_rating = 0;
+        authorName = 'Author',
+        skillUrl = this.props.skillUrl,
+        averageRating = 0,
+        totalRating = 0;
       if (skill.skill_name) {
-        skill_name = skill.skill_name;
-        skill_name = skill_name.charAt(0).toUpperCase() + skill_name.slice(1);
+        skillName = skill.skill_name;
+        skillName = skillName.charAt(0).toUpperCase() + skillName.slice(1);
       }
       if (skill.image) {
         image = `https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/${
@@ -57,97 +219,28 @@ class SkillCardList extends Component {
         description = skill.descriptions;
       }
       if (skill.author) {
-        author_name = skill.author;
+        authorName = skill.author;
       }
       if (skill.skill_rating) {
-        average_rating = parseFloat(skill.skill_rating.stars.avg_star);
-        total_rating = parseInt(skill.skill_rating.stars.total_star, 10);
+        averageRating = parseFloat(skill.skill_rating.stars.avg_star);
+        totalRating = parseInt(skill.skill_rating.stars.total_star, 10);
       }
+
+      let language = this.props.languageValue;
       cards.push(
-        <div style={styles.skillCard} key={el}>
-          <div style={styles.imageContainer}>
-            {image ? (
-              <div style={styles.image}>
-                <Link
-                  key={el}
-                  to={{
-                    pathname: `/${skill.group}/${skill.skill_tag}/${
-                      this.props.languageValue
-                    }`,
-                  }}
-                >
-                  <img alt={skill_name} src={image} style={styles.image} />
-                </Link>
-              </div>
-            ) : (
-              <CircleImage name={el} size="218" />
-            )}
-          </div>
-          <div style={styles.content}>
-            <div style={styles.header}>
-              <Link
-                key={el}
-                to={{
-                  pathname: `/${skill.group}/${skill.skill_tag}/${
-                    this.props.languageValue
-                  }`,
-                  state: {
-                    url: this.props.skillUrl,
-                    element: el,
-                    name: el,
-                    modelValue: this.props.modelValue,
-                    groupValue: skill.group,
-                    languageValue: this.props.languageValue,
-                  },
-                }}
-              >
-                <div style={styles.title}>
-                  <span>{skill_name}</span>
-                </div>
-              </Link>
-              <div style={styles.authorName}>
-                <span>{author_name}</span>
-              </div>
-            </div>
-            <div style={styles.details}>
-              <div style={styles.exampleSection}>
-                {examples.map((eg, index) => {
-                  return (
-                    <div key={index} style={styles.example}>
-                      &quot;{eg}&quot;
-                    </div>
-                  );
-                })}
-              </div>
-              <div style={styles.textData}>
-                <div style={styles.row}>
-                  <div style={styles.rating}>
-                    <Ratings
-                      style={{ display: 'flex' }}
-                      rating={average_rating || 0}
-                      widgetRatedColors="#ffbb28"
-                      widgetDimensions="20px"
-                      widgetSpacings="0px"
-                    >
-                      <Ratings.Widget />
-                      <Ratings.Widget />
-                      <Ratings.Widget />
-                      <Ratings.Widget />
-                      <Ratings.Widget />
-                    </Ratings>
-                    <span style={styles.totalRating} title="Total ratings">
-                      {total_rating || 0}
-                    </span>
-                  </div>
-                </div>
-                <div style={styles.row}>
-                  <div style={styles.descriptionTitle}>Description</div>
-                  <div style={styles.description}>{description}</div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>,
+        createListCard(
+          el,
+          skillName,
+          skillUrl,
+          authorName,
+          description,
+          image,
+          language,
+          skill,
+          examples,
+          totalRating,
+          averageRating,
+        ),
       );
     });
     this.setState({

--- a/src/components/SkillCardList/SkillCardList.js
+++ b/src/components/SkillCardList/SkillCardList.js
@@ -68,7 +68,16 @@ class SkillCardList extends Component {
           <div style={styles.imageContainer}>
             {image ? (
               <div style={styles.image}>
-                <img alt={skill_name} src={image} style={styles.image} />
+                <Link
+                  key={el}
+                  to={{
+                    pathname: `/${skill.group}/${skill.skill_tag}/${
+                      this.props.languageValue
+                    }`,
+                  }}
+                >
+                  <img alt={skill_name} src={image} style={styles.image} />
+                </Link>
               </div>
             ) : (
               <CircleImage name={el} size="218" />
@@ -133,7 +142,7 @@ class SkillCardList extends Component {
                 </div>
                 <div style={styles.row}>
                   <div style={styles.descriptionTitle}>Description</div>
-                  {description}
+                  <div style={styles.description}>{description}</div>
                 </div>
               </div>
             </div>

--- a/src/components/SkillCardList/SkillCardStyle.js
+++ b/src/components/SkillCardList/SkillCardStyle.js
@@ -6,6 +6,7 @@ const styles = {
     flexDirection: 'row',
     borderTop: '1px solid #eaeded',
     padding: 7,
+    lineHeight: '1.25',
   },
   row: {
     width: '100%',
@@ -27,6 +28,7 @@ const styles = {
     width: '180px',
     verticalAlign: 'top',
     borderRadius: '50%',
+    marginLeft: '6.4%',
   },
   title: {
     textAlign: 'left',
@@ -45,7 +47,7 @@ const styles = {
     display: 'flex',
   },
   description: {
-    fontSize: 12,
+    fontSize: '12px',
   },
   descriptionTitle: {
     fontWeight: 700,
@@ -62,7 +64,7 @@ const styles = {
     width: '100%',
   },
   content: {
-    padding: ' 0 2%',
+    paddingLeft: '4.3%',
     float: 'left',
     display: 'block',
     width: '100%',
@@ -86,11 +88,11 @@ const styles = {
     alignItems: 'center',
     textAlign: 'center',
     width: 192,
+    color: '#949494',
   },
   exampleSection: {
-    width: '55%',
-    marginRight: '2%',
-    float: 'left',
+    width: '25%',
+    marginRight: '10.8%',
     display: 'flex',
     flexDirection: 'row',
     minWidth: '260px',
@@ -98,14 +100,14 @@ const styles = {
   details: {
     width: 'auto',
     minWidth: 720,
+    display: 'flex',
   },
   textData: {
     height: '100%',
-    float: 'right',
-    fontSize: '14px',
-    width: '100%',
-    maxWidth: 270,
+    fontSize: '12px',
+    width: '40%',
     minWidth: 160,
+    marginRight: '11%',
   },
   rating: {
     positive: 'relative',


### PR DESCRIPTION
Fixes #1129 

Solves: 

- [x]  Keep skill details next to each other (like Alexa)
- [x]  Make lines between areas have some space
- [x]  For list and grid view use the same top bar blue instead of current blue
- [x]  Change font size of Sort by "Feedback" and Languages "English" drop-down display to the same as the font in the left sidebar (e.g. as in "Last 7 days")
- [x]  Link "Skill Icon" to the skill page
- [ ] Fix all skill icon images to be square and have their natural ratio/dimensions e.g. https://skills.susi.ai/Communication/TELL_ME_TIME/en

Changes: Some UI changes

Surge Deployment Link: https://pr-1129-fossasia-susi-skill-cms.surge.sh
