### PR TITLE
Fixed API call issues by using skill tag instead of skill name

### DIFF
--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -24,6 +24,7 @@ class ListSkills extends React.Component {
       isAction: false,
       showDialog: false,
       skillName: '',
+      skill_tag: '',
       skillModel: '',
       skillGroup: '',
       skillLanguage: '',
@@ -80,6 +81,7 @@ class ListSkills extends React.Component {
                     record.group,
                     record.language,
                     record.reviewStatus,
+                    record.skill_tag,
                   )
                 }
               >
@@ -108,7 +110,7 @@ class ListSkills extends React.Component {
       `/cms/changeSkillStatus.json?model=${this.state.skillModel}&group=${
         this.state.skillGroup
       }&language=${this.state.skillLanguage}&skill=${
-        this.state.skillName
+        this.state.skill_tag
       }&reviewed=${this.state.skillReviewStatus}&access_token=` +
       cookies.get('loggedIn');
     $.ajax({
@@ -146,6 +148,7 @@ class ListSkills extends React.Component {
             model: i.model,
             group: i.group,
             language: i.language,
+            skill_tag: i.skill_tag,
             reviewStatus: i.reviewed,
             type: 'public',
             author: i.author,
@@ -181,12 +184,13 @@ class ListSkills extends React.Component {
     });
   };
 
-  handleOpen = (name, model, group, language, reviewStatus) => {
+  handleOpen = (name, model, group, language, reviewStatus, skill_tag) => {
     this.setState({
       skillModel: model,
       skillGroup: group,
       skillLanguage: language,
       skillName: name,
+      skill_tag: skill_tag,
       skillReviewStatus: reviewStatus,
       showDialog: true,
     });


### PR DESCRIPTION
Fixes #1165 

Changes: Fixed API call issues by using skill tag instead of skill name

For example, earlier the query parameter `skill` in the API call while changing review status of `Anime Suggestions` Skill was:
`https://api.susi.ai/cms/changeSkillStatus.json?skill=Anime%20Suggestions&otherParameters`

Now, the API call is:
`https://api.susi.ai/cms/changeSkillStatus.json?skill=Anime_Suggestions&otherParameters`, where `Anime_Suggestions` is the `skill_tag` of the Skill

Surge Deployment Link: https://pr-1166-fossasia-susi-skill-cms.surge.sh