### PR TITLE
Add checkbox for enabling / disabling susi default skills in configure option

### DIFF
--- a/src/components/BotBuilder/BotBuilder.js
+++ b/src/components/BotBuilder/BotBuilder.js
@@ -71,6 +71,7 @@ class BotBuilder extends React.Component {
           />
         </Card>,
       );
+      return null;
     });
     this.setState({
       chatbots: chatbots,

--- a/src/components/BotBuilder/BotBuilderPages/Configure.js
+++ b/src/components/BotBuilder/BotBuilderPages/Configure.js
@@ -12,6 +12,7 @@ import {
 } from 'material-ui/Table';
 import Snackbar from 'material-ui/Snackbar';
 import SelectField from 'material-ui/SelectField';
+import Checkbox from 'material-ui/Checkbox';
 import MenuItem from 'material-ui/MenuItem';
 import Info from 'material-ui/svg-icons/action/info';
 import ReactTooltip from 'react-tooltip';
@@ -49,15 +50,41 @@ class Configure extends Component {
       code: this.props.code,
       openSnackbar: false,
       msgSnackbar: '',
+      includeSusiSkills: true,
     };
-    this.handleChangeCode = this.handleChangeCode.bind(this);
+    this.handleChangeCode = this.handleChangeCode;
   }
 
   handleChangeCode(event) {
     this.setState({ code: event });
   }
 
+  handleChangeIncludeSusiSkills = () => {
+    let value = !this.state.includeSusiSkills;
+    let code = this.state.code;
+    code = code.replace(
+      /^::enable_default_skills\s(.*)$/m,
+      `::enable_default_skills ${value ? 'yes' : 'no'}`,
+    );
+    this.setState({
+      includeSusiSkills: value,
+      code,
+    });
+  };
+
   generateConfigData = () => {
+    const enableDefaultSkillsMatch = this.state.code.match(
+      /^::enable_default_skills\s(.*)$/m,
+    );
+    if (enableDefaultSkillsMatch) {
+      let includeSusiSkills = false;
+      if (enableDefaultSkillsMatch[1] === 'yes') {
+        includeSusiSkills = true;
+      }
+      this.setState({
+        includeSusiSkills,
+      });
+    }
     configData = [];
     let newCode = this.state.code;
     let websiteData = newCode
@@ -118,6 +145,17 @@ class Configure extends Component {
             labelColor="#fff"
             onTouchTap={this.generateConfigData}
           />
+          <div>
+            <br />
+            <Checkbox
+              label="Include SUSI default skills"
+              labelPosition="right"
+              checked={this.state.includeSusiSkills}
+              labelStyle={{ fontSize: '14px' }}
+              iconStyle={{ fill: 'rgb(66, 133, 244)' }}
+              onCheck={this.handleChangeIncludeSusiSkills}
+            />
+          </div>
         </div>
         <div className="table-wrap">
           <Table className="table-root" selectable={false}>

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -54,7 +54,7 @@ class BotWizard extends React.Component {
       designCode:
         '::bodyBackground #ffffff\n::bodyBackgroundImage \n::userMessageBoxBackground #0077e5\n::userMessageTextColor #ffffff\n::botMessageBoxBackground #f8f8f8\n::botMessageTextColor #455a64\n::botIconColor #000000\n::botIconImage ',
       configCode:
-        '!Write the status of each website you want to enable or disable the bot below.\n::sites_enabled website1.com, website2.com\n::sites_disabled website3.com',
+        '!Write the status of each website you want to enable or disable the bot below.\n::sites_enabled website1.com, website2.com\n::sites_disabled website3.com\n!Choose if you want to enable the default susi skills or not\n::enable_default_skills yes',
     };
   }
 


### PR DESCRIPTION
Fixes #1138 

Changes: 
- Add `checkbox` for enabling / disabling susi default skills in the configure menu page.
- Add the parameter `enable_default_skills` in the code view of configure and synchronise it with the checkbox.

Surge Deployment Link: https://pr-1167-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17807257/42846253-0353aa4a-8a36-11e8-9a50-b09650c3f574.png)



