### PR TITLE
Add checkboxes to enable chatbot in other devices

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Configure.js
+++ b/src/components/BotBuilder/BotBuilderPages/Configure.js
@@ -48,6 +48,8 @@ class Configure extends Component {
       fontSizeCode: 14,
       lastActiveInfo: false,
       code: this.props.code,
+      myDevices: false, // use chatbot in your devices
+      publicDevices: false, // allow chatbot to be used in other people's devices
       openSnackbar: false,
       msgSnackbar: '',
       includeSusiSkills: true,
@@ -68,6 +70,32 @@ class Configure extends Component {
     );
     this.setState({
       includeSusiSkills: value,
+      code,
+    });
+  };
+
+  handleChangeIncludeInMyDevices = () => {
+    let value = !this.state.myDevices;
+    let code = this.state.code;
+    code = code.replace(
+      /^::enable_bot_in_my_devices\s(.*)$/m,
+      `::enable_bot_in_my_devices ${value ? 'yes' : 'no'}`,
+    );
+    this.setState({
+      myDevices: value,
+      code,
+    });
+  };
+
+  handleChangeIncludeInPublicDevices = () => {
+    let value = !this.state.publicDevices;
+    let code = this.state.code;
+    code = code.replace(
+      /^::enable_bot_for_other_users\s(.*)$/m,
+      `::enable_bot_for_other_users ${value ? 'yes' : 'no'}`,
+    );
+    this.setState({
+      publicDevices: value,
       code,
     });
   };
@@ -154,6 +182,22 @@ class Configure extends Component {
               labelStyle={{ fontSize: '14px' }}
               iconStyle={{ fill: 'rgb(66, 133, 244)' }}
               onCheck={this.handleChangeIncludeSusiSkills}
+            />
+            <Checkbox
+              label="Enable bot in my devices"
+              labelPosition="right"
+              checked={this.state.myDevices}
+              labelStyle={{ fontSize: '14px' }}
+              iconStyle={{ fill: 'rgb(66, 133, 244)' }}
+              onCheck={this.handleChangeIncludeInMyDevices}
+            />
+            <Checkbox
+              label="Enable bot for other users"
+              labelPosition="right"
+              checked={this.state.publicDevices}
+              labelStyle={{ fontSize: '14px' }}
+              iconStyle={{ fill: 'rgb(66, 133, 244)' }}
+              onCheck={this.handleChangeIncludeInPublicDevices}
             />
           </div>
         </div>

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -77,7 +77,7 @@ class BotWizard extends React.Component {
       designCode:
         '::bodyBackground #ffffff\n::bodyBackgroundImage \n::userMessageBoxBackground #0077e5\n::userMessageTextColor #ffffff\n::botMessageBoxBackground #f8f8f8\n::botMessageTextColor #455a64\n::botIconColor #000000\n::botIconImage ',
       configCode:
-        '!Write the status of each website you want to enable or disable the bot below.\n::sites_enabled website1.com, website2.com\n::sites_disabled website3.com\n!Choose if you want to enable the default susi skills or not\n::enable_default_skills yes',
+        "!Write the status of each website you want to enable or disable the bot below.\n::sites_enabled website1.com, website2.com\n::sites_disabled website3.com\n!Choose if you want to enable the default susi skills or not\n::enable_default_skills yes\n!Choose if you want to enable chatbot in your devices or not\n::enable_bot_in_my_devices no\n!Choose if you want to enable chatbot in other user's devices or not\n::enable_bot_for_other_users no",
     };
   }
 


### PR DESCRIPTION
Fixes #1131 

Changes: Added checkboxes for two options:
- Enable bot (private skill) in my devices
- Enable bot (private skill) in other user's devices

Surge Deployment Link: https://pr-1179-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

<img width="238" alt="screen shot 2018-07-18 at 2 25 17 pm" src="https://user-images.githubusercontent.com/31174685/42870841-85c2e94a-8a96-11e8-878c-0045bd0b695a.png">

