### PR TITLE
Fixes BotBuilder map undefined, Arrow fn warning

### DIFF
--- a/src/components/BotBuilder/BotBuilder.js
+++ b/src/components/BotBuilder/BotBuilder.js
@@ -59,19 +59,21 @@ class BotBuilder extends React.Component {
     this.setState({
       chatbots: [],
     });
-    bots.map(bot => {
-      chatbots.push(
-        <Card className="bot-template-card">
-          <RaisedButton
-            label={bot.name}
-            labelPosition="before"
-            labelStyle={{ verticalAlign: 'middle' }}
-            backgroundColor={colors.header}
-            labelColor="#fff"
-          />
-        </Card>,
-      );
-    });
+    if (bots) {
+      bots.forEach(bot => {
+        chatbots.push(
+          <Card className="bot-template-card">
+            <RaisedButton
+              label={bot.name}
+              labelPosition="before"
+              labelStyle={{ verticalAlign: 'middle' }}
+              backgroundColor={colors.header}
+              labelColor="#fff"
+            />
+          </Card>,
+        );
+      });
+    }
     this.setState({
       chatbots: chatbots,
     });


### PR DESCRIPTION
Fixes #1164 
Also fixes, warning: expected to return a arrow function
Changes: A map() creates an array, so a return is expected for all paths. No array is being returned so we can use forEach.

Surge Deployment Link: https://pr-1164-fossasia-susi-skill-cms.surge.sh