### PR TITLE
Fix regular expression in edit skill

### DIFF
--- a/src/components/SkillEditor/SkillEditor.js
+++ b/src/components/SkillEditor/SkillEditor.js
@@ -541,7 +541,7 @@ class SkillEditor extends Component {
     }
     // Check whether the image uploaded by the User
     // matches the format of the Skill image to be stored
-    if (!new RegExp(/images\/\w+\.\w+/g).test(this.state.imageUrl)) {
+    if (!new RegExp(/.+\.\w+/g).test(this.state.imageUrl)) {
       notification.open({
         message: 'Error processing your request',
         description: 'Image path must be in format of images/imageName.jpg',


### PR DESCRIPTION
Fixes #1192 

Changes: 
- change the regular expression to `/.+\.\w+/g`. This is the same regular expression used in the CreateSkill component. This will accept the `-` in the image name.

Surge Deployment Link: https://pr-1193-fossasia-susi-skill-cms.surge.sh

Screenshots for the change: NA
