### PR TITLE
Prefill edit skill commit message

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -47,6 +47,7 @@ class BotWizard extends React.Component {
         let name = this.getQueryStringValue('name');
         let group = this.getQueryStringValue('group');
         let language = this.getQueryStringValue('language');
+        this.setState({ commitMessage: `Updated Skill ${name}` });
         this.getBotDetails(name, group, language);
       }
     } else {
@@ -446,6 +447,7 @@ class BotWizard extends React.Component {
                     floatingLabelFixed={true}
                     hintText="Enter Commit Message"
                     style={{ width: '80%' }}
+                    value={this.state.commitMessage}
                     onChange={this.handleCommitMessageChange}
                   />
                   <br />

--- a/src/components/SkillEditor/SkillEditor.js
+++ b/src/components/SkillEditor/SkillEditor.js
@@ -50,7 +50,9 @@ class SkillEditor extends Component {
       showImage: true,
       image: '',
       skillUrl: null,
-      commitMessage: null,
+      commitMessage: `Updated Skill ${
+        this.props.location.pathname.split('/')[2]
+      }`,
       modelValue: 'general',
       file: null,
       codeChanged: false,


### PR DESCRIPTION
Fixes #1190 

Changes: 
- Add default `Updated Skill ${name}` commit message in Edit Skill of both public skill and in botbuilder.

Surge Deployment Link: https://pr-1194-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
For public skill:
![image](https://user-images.githubusercontent.com/17807257/42907852-bd290548-8afc-11e8-80a0-c1b96b8f79f2.png)
For botbuilder:
![image](https://user-images.githubusercontent.com/17807257/42907872-c9980aea-8afc-11e8-8973-d6d9b345dceb.png)

