### PR TITLE
Fix letter's case in skill name display

### DIFF
--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -686,8 +686,8 @@ class SkillListing extends Component {
             </div>
             <div className="meta">
               <h1 className="name">
-                {name &&
-                  name
+                {this.name &&
+                  this.name
                     .split(' ')
                     .map(data => {
                       var s = data.charAt(0).toUpperCase() + data.substring(1);


### PR DESCRIPTION
Fixes #1187 

Changes: 
- preserve skill name's case in skill preview page.

Surge Deployment Link: https://pr-1195-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
![image](https://user-images.githubusercontent.com/17807257/42911209-af24230a-8b07-11e8-9d1e-eb2455131ee0.png)

After:
![image](https://user-images.githubusercontent.com/17807257/42910815-866b0bc8-8b06-11e8-96b1-1c4f341e45bb.png)

