### PR TITLE
Fixes #1189: Set vertical resize for AceEditor components

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Configure.js
+++ b/src/components/BotBuilder/BotBuilderPages/Configure.js
@@ -165,6 +165,11 @@ class Configure extends Component {
             scrollPastEnd={false}
             wrapEnabled={true}
             editorProps={{ $blockScrolling: true }}
+            style={{
+              resize: 'vertical',
+              overflowY: 'scroll',
+              minHeight: '200px',
+            }}
           />
           <br />
           <RaisedButton

--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -899,6 +899,11 @@ class Design extends React.Component {
               scrollPastEnd={false}
               wrapEnabled={true}
               editorProps={{ $blockScrolling: true }}
+              style={{
+                resize: 'vertical',
+                overflowY: 'scroll',
+                minHeight: '200px',
+              }}
             />
           </div>
           {!this.state.loadedSettings ? (

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -665,6 +665,11 @@ export default class CreateSkill extends React.Component {
               scrollPastEnd={false}
               wrapEnabled={true}
               editorProps={{ $blockScrolling: true }}
+              style={{
+                resize: 'vertical',
+                overflowY: 'scroll',
+                minHeight: '200px',
+              }}
             />
           </div>
           <div

--- a/src/components/SkillEditor/SkillEditor.js
+++ b/src/components/SkillEditor/SkillEditor.js
@@ -737,6 +737,11 @@ class SkillEditor extends Component {
                 readOnly={true}
                 wrapEnabled={true}
                 editorProps={{ $blockScrolling: true }}
+                style={{
+                  resize: 'vertical',
+                  overflowY: 'scroll',
+                  minHeight: '200px',
+                }}
               />
             </div>
           </div>
@@ -876,6 +881,11 @@ class SkillEditor extends Component {
               scrollPastEnd={false}
               wrapEnabled={true}
               editorProps={{ $blockScrolling: true }}
+              style={{
+                resize: 'vertical',
+                overflowY: 'scroll',
+                minHeight: '200px',
+              }}
             />
           </div>
 

--- a/src/components/SkillHistory/SkillHistory.js
+++ b/src/components/SkillHistory/SkillHistory.js
@@ -252,6 +252,11 @@ class SkillHistory extends Component {
                     scrollPastEnd={false}
                     wrapEnabled={true}
                     editorProps={{ $blockScrolling: true }}
+                    style={{
+                      resize: 'vertical',
+                      overflowY: 'scroll',
+                      minHeight: '200px',
+                    }}
                   />
                 </div>
               </div>
@@ -298,6 +303,11 @@ class SkillHistory extends Component {
                     scrollPastEnd={false}
                     wrapEnabled={true}
                     editorProps={{ $blockScrolling: true }}
+                    style={{
+                      resize: 'vertical',
+                      overflowY: 'scroll',
+                      minHeight: '200px',
+                    }}
                   />
                 </div>
               </div>

--- a/src/components/SkillRollBack/SkillRollBack.js
+++ b/src/components/SkillRollBack/SkillRollBack.js
@@ -325,6 +325,11 @@ class SkillRollBack extends Component {
                     scrollPastEnd={false}
                     wrapEnabled={true}
                     editorProps={{ $blockScrolling: true }}
+                    style={{
+                      resize: 'vertical',
+                      overflowY: 'scroll',
+                      minHeight: '200px',
+                    }}
                   />
                 </div>
               </div>
@@ -350,6 +355,11 @@ class SkillRollBack extends Component {
                     scrollPastEnd={false}
                     wrapEnabled={true}
                     editorProps={{ $blockScrolling: true }}
+                    style={{
+                      resize: 'vertical',
+                      overflowY: 'scroll',
+                      minHeight: '200px',
+                    }}
                   />
                 </div>
               </div>


### PR DESCRIPTION
Fixes #1189 

Changes: Set vertical resize for AceEditor component.

A few things-
* Can't get rid of the scrollbar when height is enough since `overflow: auto` removes the resize button, will find a solution to that.

Surge Deployment Link: https://pr-1199-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![peek 2018-07-19 10-28](https://user-images.githubusercontent.com/21009455/42922525-8879a248-8b3e-11e8-8273-b2f1aa1de086.gif)
