### PR TITLE
Capitalized the first letter of names of authors on the category pages

### DIFF
--- a/src/components/SkillCardList/SkillCardStyle.js
+++ b/src/components/SkillCardList/SkillCardStyle.js
@@ -54,6 +54,7 @@ const styles = {
   },
   authorName: {
     fontSize: 12,
+    textTransform: 'capitalize',
   },
   feedback: {
     color: '#4285f4',


### PR DESCRIPTION
Fixes #1205 

Changes: Capitalized the first letter of names of authors on the category pages.

Surge Deployment Link: https://pr-1207-fossasia-susi-skill-cms.surge.sh
