### PR TITLE
Improve preview section of botbuilder

### DIFF
--- a/public/susi-chatbot.js
+++ b/public/susi-chatbot.js
@@ -158,6 +158,12 @@ function enableBot() {
 		$("body").append(mybot);
 
 		// Toggle chatbot
+		if(botWindow) {
+			$('.susi-frame-container-active').toggle();
+			$('#susi-avatar-text').toggle();
+			$('#susi-launcher-close').toggle();
+			document.getElementById('susiTextMessage').focus();
+		}
 		$('#susi-launcher').click(function() {
 			$('.susi-frame-container-active').toggle();
 			$('#susi-avatar-text').toggle();

--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -102,7 +102,7 @@ iframe{
 	border-radius: 12px;
 	margin:0;
 	padding:0;
-	border:1px solid #ccc;
+	border:0px solid #ccc;
 	overflow:hidden;
 }
 .bot-template-wrap{

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -519,7 +519,6 @@ class BotWizard extends React.Component {
                   </span>
                   <br className="display-mobile-only" />
                   <h2 className="center">Preview</h2>
-                  <br />
                   <div style={{ position: 'relative', overflow: 'hidden' }}>
                     <iframe
                       title="botPreview"


### PR DESCRIPTION
Partially fixes issue #1144 

Changes: These changes have been implemented:
- Open chatbot dialog by default on preview section.
- Remove corner box in the preview section.
- Remove space below preview.

**Note:** The shadow is being cut from sides of preview. That is due to the css of chatbot making it full screen when width is less. I have to figure out a way to fix it along keeping this feature in chatbot. I'll do that in upcoming PR. Thanks!

Surge Deployment Link: https://pr-1215-fossasia-susi-skill-cms.surge.sh

