### PR TITLE
Use standard blue for all buttons across botbuilder

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -224,9 +224,14 @@ class Build extends Component {
                     treeView: false,
                   });
                 }}
-                disabled={this.state.codeView}
               >
-                <Code />
+                <Code
+                  color={
+                    this.state.codeView
+                      ? 'rgb(66, 133, 244)'
+                      : 'rgb(158, 158, 158)'
+                  }
+                />
               </IconButton>
               <IconButton
                 tooltip="Conversation View"
@@ -237,9 +242,14 @@ class Build extends Component {
                     treeView: false,
                   });
                 }}
-                disabled={this.state.conversationView}
               >
-                <QA />
+                <QA
+                  color={
+                    this.state.conversationView
+                      ? 'rgb(66, 133, 244)'
+                      : 'rgb(158, 158, 158)'
+                  }
+                />
               </IconButton>
               <IconButton
                 tooltip="Tree View"
@@ -250,9 +260,14 @@ class Build extends Component {
                     treeView: true,
                   });
                 }}
-                disabled={this.state.treeView}
               >
-                <Timeline />
+                <Timeline
+                  color={
+                    this.state.treeView
+                      ? 'rgb(66, 133, 244)'
+                      : 'rgb(158, 158, 158)'
+                  }
+                />
               </IconButton>
             </div>
           </div>

--- a/src/components/BotBuilder/BotBuilderPages/Configure.js
+++ b/src/components/BotBuilder/BotBuilderPages/Configure.js
@@ -48,9 +48,14 @@ class Configure extends Component {
                   uiView: false,
                 });
               }}
-              disabled={this.state.codeView}
             >
-              <Code />
+              <Code
+                color={
+                  this.state.codeView
+                    ? 'rgb(66, 133, 244)'
+                    : 'rgb(158, 158, 158)'
+                }
+              />
             </IconButton>
             <IconButton
               tooltip="UI View"
@@ -60,9 +65,12 @@ class Configure extends Component {
                   uiView: true,
                 });
               }}
-              disabled={this.state.uiView}
             >
-              <Table />
+              <Table
+                color={
+                  this.state.uiView ? 'rgb(66, 133, 244)' : 'rgb(158, 158, 158)'
+                }
+              />
             </IconButton>
           </div>
         </div>

--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -38,9 +38,14 @@ class Design extends React.Component {
                   uiView: false,
                 });
               }}
-              disabled={this.state.codeView}
             >
-              <Code />
+              <Code
+                color={
+                  this.state.codeView
+                    ? 'rgb(66, 133, 244)'
+                    : 'rgb(158, 158, 158)'
+                }
+              />
             </IconButton>
             <IconButton
               tooltip="UI View"
@@ -50,9 +55,12 @@ class Design extends React.Component {
                   uiView: true,
                 });
               }}
-              disabled={this.state.uiView}
             >
-              <Table />
+              <Table
+                color={
+                  this.state.uiView ? 'rgb(66, 133, 244)' : 'rgb(158, 158, 158)'
+                }
+              />
             </IconButton>
           </div>
         </div>


### PR DESCRIPTION
Fixes #1242 

Changes: 
- Used standard blue for active button.
- Used grey for inactive button.

Surge Deployment Link: https://pr-1245-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

<img width="155" alt="screen shot 2018-07-21 at 9 27 01 pm" src="https://user-images.githubusercontent.com/31174685/43037633-d792c608-8d2c-11e8-96b6-cd8e55278ee3.png">

<img width="89" alt="screen shot 2018-07-21 at 9 27 06 pm" src="https://user-images.githubusercontent.com/31174685/43037635-d8772a64-8d2c-11e8-9ab3-5116c3c7bfb2.png">

