### PR TITLE
Improve UI of navigation options between different steps of bot wizard

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -370,7 +370,6 @@ class BotWizard extends React.Component {
                 className="botbuilder-col"
                 md={this.state.colBuild}
                 style={{
-                  overflowX: 'auto',
                   display: this.state.colBuild === 0 ? 'none' : 'block',
                 }}
               >
@@ -413,52 +412,12 @@ class BotWizard extends React.Component {
                     </div>
                   )}
                 </div>
-                <Paper
+                <div
                   style={{
-                    width: '100%',
-                    marginTop: '20px',
-                    position: 'relative',
                     display: stepIndex === 3 ? 'none' : 'block',
+                    padding: '0px 30px',
                   }}
-                  className="botBuilder-page-card"
-                  zDepth={1}
                 >
-                  {stepIndex !== 0 && stepIndex !== 3 ? (
-                    <RaisedButton
-                      label="Back"
-                      backgroundColor={colors.header}
-                      labelColor="#fff"
-                      onTouchTap={this.handlePrev}
-                      style={{ marginRight: 12 }}
-                    />
-                  ) : null}
-                  {stepIndex < 2 ? (
-                    <RaisedButton
-                      label={'Next'}
-                      backgroundColor={colors.header}
-                      labelColor="#fff"
-                      onTouchTap={this.handleNext}
-                      style={{ float: 'right' }}
-                    />
-                  ) : null}
-                  {stepIndex === 2 ? (
-                    <RaisedButton
-                      label={
-                        // eslint-disable-next-line
-                        this.state.savingSkill ? (
-                          <CircularProgress color="#ffffff" size={32} />
-                        ) : this.state.updateSkillNow ? (
-                          'Update and Deploy'
-                        ) : (
-                          'Save and Deploy'
-                        )
-                      }
-                      backgroundColor={colors.header}
-                      labelColor="#fff"
-                      style={{ float: 'right' }}
-                      onTouchTap={this.saveClick}
-                    />
-                  ) : null}
                   {stepIndex === 2 ? (
                     <TextField
                       floatingLabelText="Commit message"
@@ -469,12 +428,60 @@ class BotWizard extends React.Component {
                       onChange={this.handleCommitMessageChange}
                     />
                   ) : null}
-                  {stepIndex === 0 ? (
-                    <Link to="/botbuilder">
-                      <RaisedButton label="Cancel" />
-                    </Link>
-                  ) : null}
-                </Paper>
+                  <div
+                    style={{
+                      float: 'right',
+                      paddingLeft: '20px',
+                      paddingTop: this.state.stepIndex === 2 ? '20px' : '0px',
+                    }}
+                  >
+                    {stepIndex < 2 ? (
+                      <RaisedButton
+                        label={'Next'}
+                        backgroundColor={colors.header}
+                        labelColor="#fff"
+                        onTouchTap={this.handleNext}
+                      />
+                    ) : null}
+                    {stepIndex === 2 ? (
+                      <RaisedButton
+                        label={
+                          // eslint-disable-next-line
+                          this.state.savingSkill ? (
+                            <CircularProgress color="#ffffff" size={32} />
+                          ) : this.state.updateSkillNow ? (
+                            'Update and Deploy'
+                          ) : (
+                            'Save and Deploy'
+                          )
+                        }
+                        backgroundColor={colors.header}
+                        labelColor="#fff"
+                        onTouchTap={this.saveClick}
+                      />
+                    ) : null}
+                  </div>
+                  <div
+                    style={{
+                      float: 'right',
+                      paddingTop: this.state.stepIndex === 2 ? '20px' : '0px',
+                    }}
+                  >
+                    {stepIndex !== 0 && stepIndex !== 3 ? (
+                      <RaisedButton
+                        label="Back"
+                        backgroundColor={colors.header}
+                        labelColor="#fff"
+                        onTouchTap={this.handlePrev}
+                      />
+                    ) : null}
+                    {stepIndex === 0 ? (
+                      <Link to="/botbuilder">
+                        <RaisedButton label="Cancel" />
+                      </Link>
+                    ) : null}
+                  </div>
+                </div>
               </Col>
               {this.state.prevButton === 1 ? (
                 <div className="preview-button">


### PR DESCRIPTION
Fixes #1240 

Changes:
- Moved "Back" and "Next/Save" to the right next to each other.
- Moved "Commit Message" above buttons.
- Removed `Paper`.
- Provided proper padding.

Surge Deployment Link: https://pr-1246-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Build Tab: (You see a shadow in bottom because my browser window ended there. No difference in CSS)
<img width="680" alt="screen shot 2018-07-21 at 11 21 02 pm" src="https://user-images.githubusercontent.com/31174685/43038753-0e2c77c6-8d3d-11e8-978e-f9c29f155219.png">


Design Tab:
<img width="653" alt="screen shot 2018-07-21 at 11 21 20 pm" src="https://user-images.githubusercontent.com/31174685/43038744-e3a0a2ca-8d3c-11e8-8459-03d7236aa217.png">

Configure Tab:
<img width="658" alt="screen shot 2018-07-21 at 11 21 32 pm" src="https://user-images.githubusercontent.com/31174685/43038746-e66d7c44-8d3c-11e8-811e-9a674190bbf1.png">
