### PR TITLE
Save changes in botbuilder tabs while navigating to other tabs

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -10,15 +10,19 @@ import TreeView from './BuildViews/TreeView';
 class Build extends Component {
   constructor(props) {
     super(props);
-    let skillCode =
-      '::name <Skill_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query';
-    let skillCategory, skillLanguage, skillName;
+    let skillCode = '';
+    let skillCategory = null,
+      skillLanguage,
+      skillName;
     if (this.props.code) {
       skillCode = this.props.code;
       skillCategory = skillCode
         .split('::category ')[1]
         .split('::')[0]
         .trim();
+      if (skillCategory === '<Category>') {
+        skillCategory = null;
+      }
       skillLanguage = skillCode
         .split('::language ')[1]
         .split('::')[0]
@@ -267,6 +271,8 @@ class Build extends Component {
                   language: this.state.skillLanguage,
                   onSkillInfoChange: this.onSkillInfoChange,
                   onImageChange: this.props.onImageChange,
+                  imageFile: this.props.imageFile,
+                  image: this.props.image,
                 }}
               />
             ) : null}
@@ -294,6 +300,8 @@ Build.propTypes = {
   code: PropTypes.string,
   sendInfoToProps: PropTypes.func,
   onImageChange: PropTypes.func,
+  imageFile: PropTypes.object,
+  image: PropTypes.string,
 };
 
 export default Build;

--- a/src/components/BotBuilder/BotBuilderPages/Configure.js
+++ b/src/components/BotBuilder/BotBuilderPages/Configure.js
@@ -31,6 +31,7 @@ class Configure extends Component {
   }
 
   sendInfoToProps = values => {
+    this.props.updateConfiguration(values.code);
     this.setState({ ...values });
   };
 
@@ -90,7 +91,7 @@ class Configure extends Component {
 }
 
 Configure.propTypes = {
-  updateSettings: PropTypes.func,
+  updateConfiguration: PropTypes.func,
   code: PropTypes.string,
 };
 export default Configure;

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -36,9 +36,9 @@ class BotWizard extends React.Component {
       if (this.getQueryStringValue('template')) {
         for (let template of this.props.templates) {
           if (template.id === this.getQueryStringValue('template')) {
-            let buildCode = template.code;
+            let code = template.code;
             this.setState({
-              buildCode: buildCode,
+              buildCode: code,
               loaded: true,
             });
           }
@@ -62,7 +62,6 @@ class BotWizard extends React.Component {
     this.state = {
       finished: false,
       stepIndex: 0,
-      buildCode: '',
       themeSettingsString: '{}',
       openSnackbar: false,
       msgSnackbar: '',
@@ -76,6 +75,14 @@ class BotWizard extends React.Component {
       imageChanged: false,
       loaded: false,
       commitMessage: '',
+      groupValue: null,
+      languageValue: '',
+      expertValue: '',
+      file: null,
+      imageUrl: '',
+      image: '',
+      buildCode:
+        '::name <Skill_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query',
       designCode:
         '::bodyBackground #ffffff\n::bodyBackgroundImage \n::userMessageBoxBackground #0077e5\n::userMessageTextColor #ffffff\n::botMessageBoxBackground #f8f8f8\n::botMessageTextColor #455a64\n::botIconColor #000000\n::botIconImage ',
       configCode:
@@ -146,11 +153,18 @@ class BotWizard extends React.Component {
   };
 
   updateSettings = themeSettingsString => {
-    this.setState({ themeSettingsString });
+    this.setState({
+      designCode: JSON.parse(themeSettingsString).code,
+      themeSettingsString,
+    });
   };
 
   sendInfoToProps = values => {
-    this.setState({ ...values });
+    this.setState({ ...values, buildCode: values.code });
+  };
+
+  updateConfiguration = code => {
+    this.setState({ configCode: code });
   };
 
   getStepContent(stepIndex) {
@@ -160,6 +174,9 @@ class BotWizard extends React.Component {
           <Build
             sendInfoToProps={this.sendInfoToProps}
             code={this.state.buildCode}
+            imageFile={this.state.file}
+            image={this.state.image}
+            imageUrl={this.state.imageUrl}
             onImageChange={() => this.setState({ imageChanged: true })}
           />
         );
@@ -171,7 +188,12 @@ class BotWizard extends React.Component {
           />
         );
       case 2:
-        return <Configure code={this.state.configCode} />;
+        return (
+          <Configure
+            updateConfiguration={this.updateConfiguration}
+            code={this.state.configCode}
+          />
+        );
       case 3:
         return <Deploy />;
       default:
@@ -210,7 +232,7 @@ class BotWizard extends React.Component {
   saveClick = () => {
     // save the skill on the server
     let self = this;
-    let code = this.state.code;
+    let code = this.state.buildCode;
     code = self.state.configCode + '\n' + self.state.designCode + '\n' + code;
     code = '::author_email ' + cookies.get('emailId') + '\n' + code;
     code = '::protected Yes\n' + code;
@@ -331,8 +353,6 @@ class BotWizard extends React.Component {
       });
     this.handleNext();
   };
-
-  updateSkill = () => {};
 
   render() {
     const muiTheme = getMuiTheme({

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -66,6 +66,13 @@ export default class CreateSkill extends React.Component {
           () => this.handleGroupChange(null, 0, this.props.botBuilder.category),
         );
       }
+      if (this.props.botBuilder.image) {
+        this.setState({
+          image: this.props.botBuilder.image,
+          file: this.props.botBuilder.imageFile,
+          imageUrl: this.props.botBuilder.imageUrl,
+        });
+      }
     }
   }
 
@@ -332,6 +339,7 @@ export default class CreateSkill extends React.Component {
         code: this.state.code,
         expertValue: this.state.expertValue,
         imageUrl: this.state.imageUrl,
+        image: this.state.image,
         groupValue: this.state.groupValue,
         languageValue: this.state.languageValue,
         file: this.state.file,
@@ -485,7 +493,7 @@ export default class CreateSkill extends React.Component {
     if (event.target.files && event.target.files[0]) {
       let reader = new FileReader();
       reader.onload = e => {
-        this.setState({ image: e.target.result });
+        this.setState({ image: e.target.result }, () => this.sendInfoToProps());
       };
       reader.readAsDataURL(event.target.files[0]);
       self.setState({
@@ -548,7 +556,6 @@ export default class CreateSkill extends React.Component {
           <Paper style={style} zDepth={1}>
             <Info
               style={styles.helpIcon}
-              isCapture={true}
               data-tip={
                 'Know more about <a href="https://github.com/fossasia/susi_skill_cms/blob/master/docs/Skill_Tutorial.md" rel="noopener noreferrer" target="_blank" >SUSI Skill Language</a>'
               }


### PR DESCRIPTION
Fixes #1116 

Changes:
- save changes in `Build`, `Design`, `Configure` views while navigating from one tab to another.

Surge Deployment Link: https://pr-1247-fossasia-susi-skill-cms.surge.sh


