### PR TITLE
make headings to h1 in botbuilder

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -211,9 +211,9 @@ class Build extends Component {
       <div className="menu-page">
         <div>
           <div style={{ display: 'flex', flexDirection: 'row' }}>
-            <h2 style={{ lineHeight: '50px' }}>
+            <h1 style={{ lineHeight: '50px' }}>
               1. Add a new skill to your bot
-            </h2>
+            </h1>
             <div style={{ marginLeft: 'auto', marginRight: '0px' }}>
               <IconButton
                 tooltip="Code View"

--- a/src/components/BotBuilder/BotBuilderPages/Configure.js
+++ b/src/components/BotBuilder/BotBuilderPages/Configure.js
@@ -38,7 +38,7 @@ class Configure extends Component {
     return (
       <div className="menu-page">
         <div style={{ display: 'flex', flexDirection: 'row' }}>
-          <h2 style={{ lineHeight: '50px' }}>3. Configure your bot</h2>
+          <h1 style={{ lineHeight: '50px' }}>3. Configure your bot</h1>
           <div style={{ marginLeft: 'auto', marginRight: '0px' }}>
             <IconButton
               tooltip="Code View"

--- a/src/components/BotBuilder/BotBuilderPages/Deploy.js
+++ b/src/components/BotBuilder/BotBuilderPages/Deploy.js
@@ -14,9 +14,9 @@ class Deploy extends Component {
   render() {
     return (
       <div className="menu-page">
-        <h2 style={{ lineHeight: '50px' }}>
+        <h1 style={{ lineHeight: '50px' }}>
           4. Deploy your bot to your own website
-        </h2>
+        </h1>
         <br />
         <div className="code-wrap show">
           <div className="code-box">

--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -28,7 +28,7 @@ class Design extends React.Component {
     return (
       <div className="center menu-page">
         <div style={{ display: 'flex', flexDirection: 'row' }}>
-          <h2 style={{ lineHeight: '50px' }}>2. Design your bot</h2>
+          <h1 style={{ lineHeight: '50px' }}>2. Design your bot</h1>
           <div style={{ marginLeft: 'auto', marginRight: '0px' }}>
             <IconButton
               tooltip="Code View"


### PR DESCRIPTION
Fixes #1241 

Changes: Change headings in botbuilder pages from `<h2>` to `<h1>`

Surge Deployment Link: https://pr-[ADD_PULL_REQUEST_NUMBER_HERE]-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17807257/43039888-61e6367e-8d54-11e8-8090-1adc13122af2.png)
![image](https://user-images.githubusercontent.com/17807257/43039889-6930b742-8d54-11e8-9d22-119b43f77011.png)
![image](https://user-images.githubusercontent.com/17807257/43039891-74e07fe6-8d54-11e8-8586-514ff7145701.png)
![image](https://user-images.githubusercontent.com/17807257/43039892-77eb7434-8d54-11e8-8bb9-fa190155ea12.png)

