### PR TITLE
Disabled editing for the Skills having edit status `false` for non-Admin users

### DIFF
--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -210,7 +210,7 @@ class ListSkills extends React.Component {
       skillName: name,
       skill_tag: skill_tag,
       skillReviewStatus: reviewStatus,
-      skilleditStatus: editStatus,
+      skillEditStatus: editStatus,
       showDialog: true,
     });
   };

--- a/src/components/SkillEditor/SkillEditor.js
+++ b/src/components/SkillEditor/SkillEditor.js
@@ -49,6 +49,7 @@ class SkillEditor extends Component {
     }
     this.state = {
       showImage: true,
+      editable: true,
       image: '',
       skillUrl: null,
       commitMessage: `Updated Skill ${
@@ -189,11 +190,13 @@ class SkillEditor extends Component {
   componentDidMount() {
     // Check if admin is logged in or not
     document.title = 'SUSI.AI - Edit Skill';
-    if (cookies.get('showAdmin') === true) {
+
+    if (cookies.get('showAdmin') === 'true') {
       this.setState({
         showAdmin: true,
       });
     }
+
     self = this;
     self.loadgroups();
 
@@ -246,6 +249,9 @@ class SkillEditor extends Component {
         jsonp: 'callback',
         crossDomain: true,
         success: function(data) {
+          this.setState({
+            editable: data.skill_metadata.editable,
+          });
           self.updateData(data.skill_metadata);
         },
         error: function(e) {
@@ -287,6 +293,9 @@ class SkillEditor extends Component {
       jsonp: 'callback',
       crossDomain: true,
       success: function(data) {
+        self.setState({
+          editable: data.skill_metadata.editable,
+        });
         self.updateData(data.skill_metadata);
       },
     });
@@ -751,6 +760,78 @@ class SkillEditor extends Component {
         </div>
       );
     }
+    if (
+      cookies.get('loggedIn') &&
+      !this.state.editable &&
+      !this.state.showAdmin
+    ) {
+      return (
+        <div>
+          <StaticAppBar {...this.props} />
+          <div style={styles.home}>
+            <p style={styles.titleStyle}>
+              THIS SKILL IS NOT EDITABLE. IT IS CURRENTLY LOCKED BY ADMINS. YOU
+              CAN STILL SEE THE CODE OF THE SKILL.
+            </p>
+            <p style={styles.subtitleStyle}>
+              There can be various reasons for non-editable skills. <br />For
+              example if the skill is a standard skill, if there was vandalism
+              happening in the skill or if there is a dispute about the skill.
+            </p>
+            <p style={styles.description}>
+              The code is shown below in a read only mode.
+            </p>
+            <div style={styles.codeEditor}>
+              <div style={styles.toolbar}>
+                <span style={styles.button}>
+                  <Icon type="cloud-download" style={styles.icon} />
+                  Download as text
+                </span>
+                <span style={styles.button}>
+                  Size{' '}
+                  <SelectField
+                    style={{ width: '60px' }}
+                    onChange={this.handleFontChange}
+                  >
+                    {fontsizes}
+                  </SelectField>
+                </span>
+
+                <span style={styles.button}>
+                  Theme{' '}
+                  <SelectField
+                    style={{ width: '150px' }}
+                    onChange={this.handleThemeChange}
+                  >
+                    {codeEditorThemes}
+                  </SelectField>
+                </span>
+              </div>
+              <AceEditor
+                mode="java"
+                theme={this.state.editorTheme}
+                width="100%"
+                fontSize={this.state.fontSizeCode}
+                height="400px"
+                value={this.state.code}
+                showPrintMargin={false}
+                name="skill_code_editor"
+                onChange={this.handleChange.bind(this)}
+                scrollPastEnd={false}
+                readOnly={true}
+                wrapEnabled={true}
+                editorProps={{ $blockScrolling: true }}
+                style={{
+                  resize: 'vertical',
+                  overflowY: 'scroll',
+                  minHeight: '200px',
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      );
+    }
     return (
       <div>
         <StaticAppBar {...this.props} />
@@ -1024,6 +1105,13 @@ const styles = {
     fontWeight: 'bold',
     marginBottom: '30px',
     fontSize: '20px',
+    marginTop: '20px',
+  },
+  subtitleStyle: {
+    textAlign: 'center',
+    fontWeight: 'bold',
+    marginBottom: '30px',
+    fontSize: '16px',
     marginTop: '20px',
   },
   description: {

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -89,6 +89,7 @@ class SkillListing extends Component {
       skill_feedback: [],
       device_usage_data: [],
       ratings_over_time: [],
+      editStatus: true,
     };
 
     let clickedSkill = this.props.location.pathname.split('/')[2];
@@ -205,6 +206,9 @@ class SkillListing extends Component {
         jsonp: 'callback',
         crossDomain: true,
         success: function(data) {
+          self.setState({
+            editStatus: data.skill_metadata.editable,
+          });
           self.updateData(data.skill_metadata);
         },
       });


### PR DESCRIPTION
Fixes #1251 

**Changes:** Disabled editing for the Skills having edit status `false` for non-Admin users. Also fixed a minor typo which was causing issues in the default value of the dropdown.

As the PR on the server and on the CMS have been merged (https://github.com/fossasia/susi_server/pull/1035 and https://github.com/fossasia/susi_skill_cms/pull/1244 respectively), this PR can be tested by going to the Admin Panel and changing the Edit status of any Skill.

**Surge Deployment Link:** https://pr-1252-fossasia-susi-skill-cms.surge.sh

**Screenshots for the change:**

<img width="1439" alt="screen shot 2018-07-22 at 5 08 04 pm" src="https://user-images.githubusercontent.com/31135861/43045212-d8d97872-8dd1-11e8-8685-40f384d6aa1c.png">
