### PR TITLE
Use grey color for preview buttons on bot wizard

### DIFF
--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -224,7 +224,7 @@ input[type=file]{
     z-index: 1;
     top: 75px;
     right: 0;
-    background-color: #111;
+    background-color: rgb(158, 158, 158);
     overflow-x: hidden;
     padding-top: 20px;
 }

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -598,6 +598,7 @@ const styles = {
     top: '0',
     width: '35px',
     height: '35px',
+    color: 'rgb(158, 158, 158)',
     cursor: 'pointer',
     display: window.innerWidth < 769 ? 'none' : 'inherit',
   },


### PR DESCRIPTION
Fixes #1242 

Changes: Used grey color for preview buttons on bot wizard

Surge Deployment Link: https://pr-1253-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

<img width="62" alt="screen shot 2018-07-22 at 2 32 32 pm" src="https://user-images.githubusercontent.com/31174685/43044040-35da9c06-8dbc-11e8-88fc-c34067eb3308.png">

<img width="52" alt="screen shot 2018-07-22 at 2 32 38 pm" src="https://user-images.githubusercontent.com/31174685/43044041-36ce1250-8dbc-11e8-8b27-c1f078dd647f.png">

