### PR TITLE
Use SUSI server's API to fetch public skill's images

### DIFF
--- a/src/components/AuthorSkills/AuthorSkills.js
+++ b/src/components/AuthorSkills/AuthorSkills.js
@@ -70,14 +70,11 @@ class AuthorSkills extends Component {
               let temp = name.split('_');
               name = temp[0] + ' ' + temp[1];
             }
-
-            let image =
-              'https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/general/' +
-              parse[4] +
-              '/' +
-              parse[5] +
-              '/images/' +
-              parse[6].split('.')[0];
+            let image = `${
+              urls.API_URL
+            }/cms/getImage.png?model=general&language=${parse[5]}&group=${
+              parse[4]
+            }&image=${'/images/' + parse[6].split('.')[0]}`;
             let image1 = image + '.png';
             let image2 = image + '.jpg';
 

--- a/src/components/SkillCardGrid/SkillCardGrid.js
+++ b/src/components/SkillCardGrid/SkillCardGrid.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import CircleImage from '../CircleImage/CircleImage';
 
 import styles from '../BrowseSkill/SkillStyle';
-
+import urls from '../../Utils/urls';
 class SkillCardGrid extends Component {
   constructor(props) {
     super(props);
@@ -45,15 +45,9 @@ class SkillCardGrid extends Component {
         skill_name = 'Name not available';
       }
       if (skill.image) {
-        image =
-          'https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/' +
-          skill.model +
-          '/' +
-          skill.group +
-          '/' +
-          skill.language +
-          '/' +
-          skill.image;
+        image = `${urls.API_URL}/cms/getImage.png?model=${
+          skill.model
+        }&language=${skill.language}&group=${skill.group}&image=${skill.image}`;
       } else {
         image = '';
       }

--- a/src/components/SkillCardList/SkillCardList.js
+++ b/src/components/SkillCardList/SkillCardList.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import CircleImage from '../CircleImage/CircleImage';
 import styles from './SkillCardStyle';
-
+import urls from '../../Utils/urls';
 function createListCard(
   el,
   skillName,
@@ -213,9 +213,9 @@ class SkillCardList extends Component {
         skillName = skillName.charAt(0).toUpperCase() + skillName.slice(1);
       }
       if (skill.image) {
-        image = `https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/${
+        image = `${urls.API_URL}/cms/getImage.png?model=${
           skill.model
-        }/${skill.group}/${skill.language}/${skill.image}`;
+        }&language=${skill.language}&group=${skill.group}&image=${skill.image}`;
       }
       if (skill.examples) {
         examples = skill.examples;

--- a/src/components/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/SkillCardScrollList/SkillCardScrollList.js
@@ -7,6 +7,7 @@ import CircleImage from '../CircleImage/CircleImage';
 import FloatingActionButton from 'material-ui/FloatingActionButton';
 import NavigationChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
 import NavigationChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
+import urls from '../../Utils/urls';
 
 import styles from './ScrollStyle';
 
@@ -114,15 +115,9 @@ class SkillCardScrollList extends Component {
         skill_name = 'Name not available';
       }
       if (skill.image) {
-        image =
-          'https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/' +
-          skill.model +
-          '/' +
-          skill.group +
-          '/' +
-          skill.language +
-          '/' +
-          skill.image;
+        image = `${urls.API_URL}/cms/getImage.png?model=${
+          skill.model
+        }&language=${skill.language}&group=${skill.group}&image=${skill.image}`;
       } else {
         image = '';
       }

--- a/src/components/SkillEditor/SkillEditor.js
+++ b/src/components/SkillEditor/SkillEditor.js
@@ -111,9 +111,9 @@ class SkillEditor extends Component {
   }
   updateData(skillData) {
     if (skillData.image) {
-      this.imgUrl = `https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/general/${
-        this.state.groupValue
-      }/${this.state.languageValue}/${skillData.image}`;
+      this.imgUrl = `${urls.API_URL}/cms/getImage.png?model=general&language=${
+        this.languageValue
+      }&group=${this.groupValue}&image=${skillData.image}`;
     } else {
       this.imgUrl =
         'https://pbs.twimg.com/profile_images/904617517489979392/6Hff65Th.jpg';

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -396,9 +396,9 @@ class SkillListing extends Component {
     if (skillData.skill_rating) {
       this.saveSkillRatings(skillData.skill_rating.stars);
     }
-    let imgUrl = `https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/general/${
-      this.groupValue
-    }/${this.languageValue}/${skillData.image}`;
+    let imgUrl = `${urls.API_URL}/cms/getImage.png?model=general&language=${
+      this.languageValue
+    }&group=${this.groupValue}&image=${skillData.image}`;
     if (!skillData.image) {
       imgUrl =
         'https://pbs.twimg.com/profile_images/904617517489979392/6Hff65Th.jpg';


### PR DESCRIPTION
Fixes #1254 

Changes: Replace github url with the SUSI Server's API to fetch public skill images. (The API on the server was made by PR https://github.com/fossasia/susi_server/pull/1036).

Surge Deployment Link: https://pr-1255-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
Images are sucessfully fetched from SUSI Server:
![image](https://user-images.githubusercontent.com/17807257/43044399-c2ce40d0-8dc2-11e8-9e88-43c6c47eeaae.png)

