### PR TITLE
Fixes #1257: Show skill view switch option on start page but not when metrics are shown

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -421,13 +421,7 @@ export default class BrowseSkill extends React.Component {
       );
     }
 
-    let showSortBy =
-      this.props.routeType ||
-      this.state.searchQuery.length > 0 ||
-      this.state.ratingRefine ||
-      this.state.timeFilter;
-
-    let showSkillsMenu =
+    let metricsHidden =
       this.props.routeType ||
       this.state.searchQuery.length > 0 ||
       this.state.ratingRefine ||
@@ -560,7 +554,7 @@ export default class BrowseSkill extends React.Component {
               {/* Refine by rating section*/}
               <Subheader style={styles.sidebarSubheader}>Refine by</Subheader>
 
-              {showSkillsMenu && (
+              {metricsHidden && (
                 <div
                   style={{
                     marginBottom: '12px',
@@ -715,7 +709,7 @@ export default class BrowseSkill extends React.Component {
                   value={this.state.searchQuery}
                 />
               </div>
-              {showSortBy && (
+              {metricsHidden && (
                 <SelectField
                   floatingLabelText="Sort by"
                   value={this.state.filter}
@@ -817,7 +811,7 @@ export default class BrowseSkill extends React.Component {
               >
                 {this.languageMenuItems(languageValue)}
               </SelectField>
-              {this.props.routeType && (
+              {metricsHidden && (
                 <RadioButtonGroup
                   name="view_type"
                   defaultSelected="list"


### PR DESCRIPTION
Fixes #1257 

Changes: Show skill view switch option on start page but not when metrics are shown, switcher was not initially shown when time filter is applied or refine by ratings is applied.

Surge Deployment Link: https://pr-1259-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![peek 2018-07-22 20-56](https://user-images.githubusercontent.com/21009455/43047222-bd6a8656-8df1-11e8-9e99-b4c16d27ee4f.gif)
