### PR TITLE
Fix bugs in editing of saved bots

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -288,6 +288,7 @@ class Build extends Component {
                   onImageChange: this.props.onImageChange,
                   imageFile: this.props.imageFile,
                   image: this.props.image,
+                  imageUrl: this.props.imageUrl,
                 }}
               />
             ) : null}
@@ -317,6 +318,7 @@ Build.propTypes = {
   onImageChange: PropTypes.func,
   imageFile: PropTypes.object,
   image: PropTypes.string,
+  imageUrl: PropTypes.string,
 };
 
 export default Build;

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -44,6 +44,7 @@ class BotWizard extends React.Component {
           }
         }
       } else {
+        // editing a saved bot
         let name = this.getQueryStringValue('name');
         let group = this.getQueryStringValue('group');
         let language = this.getQueryStringValue('language');
@@ -110,11 +111,27 @@ class BotWizard extends React.Component {
           text.split('::bodyBackground ')[1].split('::name')[0];
         let configCode =
           '!Write' + text.split('!Write')[1].split('::bodyBackground')[0];
+        const imageNameMatch = buildCode.match(/^::image\s(.*)$/m);
+        let imagePreviewUrl = `${
+          urls.API_URL
+        }/cms/getImage.png?access_token=${cookies.get(
+          'loggedIn',
+        )}&language=${language}&group=${group}&image=${imageNameMatch[1]}`;
+        let savedSkillOld = {
+          OldGroup: group,
+          OldLanguage: language,
+          OldSkill: name,
+          old_image_name: imageNameMatch[1].replace('images/', ''),
+        };
         this.setState({
           buildCode: buildCode,
           designCode: designCode,
           configCode: configCode,
           loaded: true,
+          image: imagePreviewUrl,
+          imageUrl: imageNameMatch[1],
+          updateSkillNow: true,
+          savedSkillOld,
         });
       }.bind(this),
       error: function(err) {
@@ -253,7 +270,7 @@ class BotWizard extends React.Component {
       });
       return 0;
     }
-    if (this.state.file === null) {
+    if (this.state.file === null && this.state.updateSkillNow === false) {
       notification.open({
         message: 'Error Processing your Request',
         description: 'Image Not Given',

--- a/src/components/CreateSkill/CreateSkill.js
+++ b/src/components/CreateSkill/CreateSkill.js
@@ -343,7 +343,6 @@ export default class CreateSkill extends React.Component {
         groupValue: this.state.groupValue,
         languageValue: this.state.languageValue,
         file: this.state.file,
-        commitMessage: this.state.commitMessage,
       });
     }
   };


### PR DESCRIPTION
Fixes #1258 
Fixes #1120 

Changes: 
- prefill the skill's image which was previously saved
- change the API to `ModifySkill` instead of `CreateSkill` while updating a saved skill

Surge Deployment Link: https://pr-1263-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
Preview of image previously saved:
![image](https://user-images.githubusercontent.com/17807257/43048576-54a72b9a-8e07-11e8-8f16-e197d40f1c28.png)

Successfully saved skill after editing:
![image](https://user-images.githubusercontent.com/17807257/43048571-482b275e-8e07-11e8-8ed6-a2fb0806bd61.png)
 
