### PR TITLE
Linked all Skill names to their Skill pages in My Ratings section

### DIFF
--- a/src/components/Dashboard/MyRatings.js
+++ b/src/components/Dashboard/MyRatings.js
@@ -51,6 +51,8 @@ class MyRatings extends Component {
             let skill_name = Object.keys(i)[0];
             ratingsData.push({
               skill_name: skill_name,
+              group: i[skill_name].group,
+              language: i[skill_name].language,
               skill_star: i[skill_name].stars,
               rating_timestamp: i[skill_name].timestamp,
             });
@@ -97,10 +99,24 @@ class MyRatings extends Component {
                   return (
                     <TableRow key={index}>
                       <TableRowColumn style={{ fontSize: '16px' }}>
-                        {(
-                          skill.skill_name.charAt(0).toUpperCase() +
-                          skill.skill_name.slice(1)
-                        ).replace(/[_-]/g, ' ')}
+                        <Link
+                          to={{
+                            pathname:
+                              '/' +
+                              skill.group +
+                              '/' +
+                              skill.skill_name
+                                .toLowerCase()
+                                .replace(/ /g, '_') +
+                              '/' +
+                              skill.language,
+                          }}
+                        >
+                          {(
+                            skill.skill_name.charAt(0).toUpperCase() +
+                            skill.skill_name.slice(1)
+                          ).replace(/[_-]/g, ' ')}
+                        </Link>
                       </TableRowColumn>
                       <TableRowColumn style={{ fontSize: '16px' }}>
                         {skill.skill_star}


### PR DESCRIPTION
Fixes #1119 

Changes: Linked all Skill names to their Skill pages in `My Ratings` section, similar to how they are linked in `My Skills` section.

Surge Deployment Link: https://pr-1265-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
<img width="399" alt="screen shot 2018-07-23 at 5 13 36 am" src="https://user-images.githubusercontent.com/31135861/43051424-34dd47f6-8e37-11e8-8522-6c885448a6c3.png">
