### PR TITLE
Fixes #1271: Fix divider margin on sidebar

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -530,7 +530,7 @@ export default class BrowseSkill extends React.Component {
                   style={styles.sidebarMenuItem}
                 />
               )}
-              <Divider style={{ margin: '8px 0' }} />
+              <Divider style={{ marginLeft: '16px', marginRight: '16px' }} />
 
               {this.props.routeType === 'category' ? (
                 <div className="category-sidebar-section">
@@ -556,7 +556,7 @@ export default class BrowseSkill extends React.Component {
                 </div>
               )}
 
-              <Divider style={{ margin: '8px 0' }} />
+              <Divider style={{ marginLeft: '16px', marginRight: '16px' }} />
               {/* Refine by rating section*/}
               <Subheader style={styles.sidebarSubheader}>Refine by</Subheader>
 


### PR DESCRIPTION
Fixes #1271 

Changes: Set margin property on the Divider component on the sidebar.
Due to some CSS overriding the `margin: a b c d` doesn't work as well and thus used right and left margin separately, please try to pull the repo and make those changes yourself before suggestion.

Surge Deployment Link: https://pr-1274-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43061728-eff41394-8e73-11e8-9622-046c67030297.png)
