### PR TITLE
Fixes #1275: Fix bug with refine by rating filter

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -374,7 +374,8 @@ export default class BrowseSkill extends React.Component {
 
   refineByRating = (skills, ratingRefine) => {
     return skills.filter(
-      skill => skill.skill_rating.stars.avg_star >= ratingRefine,
+      skill =>
+        skill.skill_rating && skill.skill_rating.stars.avg_star >= ratingRefine,
     );
   };
 


### PR DESCRIPTION
Fixes #1275 

Changes: Refine by rating works normally now, added a quick check.

Surge Deployment Link: https://pr-1276-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43063004-38b3704e-8e78-11e8-8824-013bd6421de2.png)
