### PR TITLE
Add dynamic table in configure tab and remove placeholders

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -87,7 +87,7 @@ class BotWizard extends React.Component {
       designCode:
         '::bodyBackground #ffffff\n::bodyBackgroundImage \n::userMessageBoxBackground #0077e5\n::userMessageTextColor #ffffff\n::botMessageBoxBackground #f8f8f8\n::botMessageTextColor #455a64\n::botIconColor #000000\n::botIconImage ',
       configCode:
-        "!Write the status of each website you want to enable or disable the bot below.\n::sites_enabled website1.com, website2.com\n::sites_disabled website3.com\n!Choose if you want to enable the default susi skills or not\n::enable_default_skills yes\n!Choose if you want to enable chatbot in your devices or not\n::enable_bot_in_my_devices no\n!Choose if you want to enable chatbot in other user's devices or not\n::enable_bot_for_other_users no",
+        "::allow_bot_only_on_own_sites no\n!Write all the domains below separated by commas on which you want to enable your chatbot\n::allowed_sites \n!Choose if you want to enable the default susi skills or not\n::enable_default_skills yes\n!Choose if you want to enable chatbot in your devices or not\n::enable_bot_in_my_devices no\n!Choose if you want to enable chatbot in other user's devices or not\n::enable_bot_for_other_users no",
     };
   }
 


### PR DESCRIPTION
Partially fixes issue #1237 

Changes: 
- Removed material-ui table.
- Used ant design table instead.
- Removed placeholders.
- Changed code view as per the requirement.
- Added checkbox for user to enable/disable chatbot on own websites.
- Added feature for used to add websites.

NEXT STEP: Synchronise UI view with code view.

Surge Deployment Link: https://pr-1278-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

![jul-23-2018 19-46-36](https://user-images.githubusercontent.com/31174685/43082364-80fd5d40-8eb1-11e8-8028-7a6354bd3e0d.gif)

