### PR TITLE
Removed user role BOT from dropdown in Admin Panel

### DIFF
--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -332,11 +332,6 @@ export default class ListUser extends Component {
                 autoWidth={false}
               >
                 <MenuItem
-                  primaryText="BOT"
-                  value="bot"
-                  className="setting-item"
-                />
-                <MenuItem
                   primaryText="USER"
                   value="user"
                   className="setting-item"


### PR DESCRIPTION
Fixes #1266 

Changes: Removed user role `BOT` from dropdown in Admin Panel. 
Relevant PR on server: https://github.com/fossasia/susi_server/pull/1047

Surge Deployment Link: https://pr-1296-fossasia-susi-skill-cms.surge.sh
