### PR TITLE
Fixes #1302: Rating section on skill cards should redirect to feedback page for that skill

### DIFF
--- a/src/components/SkillCardGrid/SkillCardGrid.js
+++ b/src/components/SkillCardGrid/SkillCardGrid.js
@@ -100,22 +100,44 @@ class SkillCardGrid extends Component {
             </div>
           </Link>
           <div style={styles.rating}>
-            <Ratings
-              style={{ display: 'flex' }}
-              rating={average_rating || 0}
-              widgetRatedColors="#ffbb28"
-              widgetDimensions="20px"
-              widgetSpacings="0px"
+            <Link
+              key={el}
+              to={{
+                pathname:
+                  '/' +
+                  skill.group +
+                  '/' +
+                  skill.skill_tag +
+                  '/' +
+                  this.props.languageValue +
+                  '/feedbacks',
+                state: {
+                  url: this.props.skillUrl,
+                  element: el,
+                  name: el,
+                  modelValue: this.props.modelValue,
+                  groupValue: skill.group,
+                  languageValue: this.props.languageValue,
+                },
+              }}
             >
-              <Ratings.Widget />
-              <Ratings.Widget />
-              <Ratings.Widget />
-              <Ratings.Widget />
-              <Ratings.Widget />
-            </Ratings>
-            <span style={styles.totalRating} title="Total ratings">
-              {total_rating || 0}
-            </span>
+              <Ratings
+                style={{ display: 'flex' }}
+                rating={average_rating || 0}
+                widgetRatedColors="#ffbb28"
+                widgetDimensions="20px"
+                widgetSpacings="0px"
+              >
+                <Ratings.Widget />
+                <Ratings.Widget />
+                <Ratings.Widget />
+                <Ratings.Widget />
+                <Ratings.Widget />
+              </Ratings>
+              <span style={styles.totalRating} title="Total ratings">
+                {total_rating || 0}
+              </span>
+            </Link>
           </div>
         </Card>,
       );

--- a/src/components/SkillCardList/SkillCardList.js
+++ b/src/components/SkillCardList/SkillCardList.js
@@ -58,22 +58,39 @@ function createListCard(
               <span>Skills for SUSI</span>
             </div>
             <div style={styles.rating}>
-              <Ratings
-                style={{ display: 'flex' }}
-                rating={averageRating || 0}
-                widgetRatedColors="#ffbb28"
-                widgetDimensions="20px"
-                widgetSpacings="0px"
+              <Link
+                key={el}
+                to={{
+                  pathname: `/${skill.group}/${
+                    skill.skill_tag
+                  }/${language}/feedbacks`,
+                  state: {
+                    url: skillUrl,
+                    element: el,
+                    name: el,
+                    modelValue: skill.model,
+                    groupValue: skill.group,
+                    languageValue: language,
+                  },
+                }}
               >
-                <Ratings.Widget />
-                <Ratings.Widget />
-                <Ratings.Widget />
-                <Ratings.Widget />
-                <Ratings.Widget />
-              </Ratings>
-              <span style={styles.totalRating} title="Total ratings">
-                {totalRating || 0}
-              </span>
+                <Ratings
+                  style={{ display: 'flex' }}
+                  rating={averageRating || 0}
+                  widgetRatedColors="#ffbb28"
+                  widgetDimensions="20px"
+                  widgetSpacings="0px"
+                >
+                  <Ratings.Widget />
+                  <Ratings.Widget />
+                  <Ratings.Widget />
+                  <Ratings.Widget />
+                  <Ratings.Widget />
+                </Ratings>
+                <span style={styles.totalRating} title="Total ratings">
+                  {totalRating || 0}
+                </span>
+              </Link>
             </div>
           </div>
         </div>
@@ -143,22 +160,39 @@ function createListCard(
           <div style={styles.textData}>
             <div style={styles.row}>
               <div style={styles.rating}>
-                <Ratings
-                  style={{ display: 'flex' }}
-                  rating={averageRating || 0}
-                  widgetRatedColors="#ffbb28"
-                  widgetDimensions="20px"
-                  widgetSpacings="0px"
+                <Link
+                  key={el}
+                  to={{
+                    pathname: `/${skill.group}/${
+                      skill.skill_tag
+                    }/${language}/feedbacks`,
+                    state: {
+                      url: skillUrl,
+                      element: el,
+                      name: el,
+                      modelValue: skill.model,
+                      groupValue: skill.group,
+                      languageValue: language,
+                    },
+                  }}
                 >
-                  <Ratings.Widget />
-                  <Ratings.Widget />
-                  <Ratings.Widget />
-                  <Ratings.Widget />
-                  <Ratings.Widget />
-                </Ratings>
-                <span style={styles.totalRating} title="Total ratings">
-                  {totalRating || 0}
-                </span>
+                  <Ratings
+                    style={{ display: 'flex' }}
+                    rating={averageRating || 0}
+                    widgetRatedColors="#ffbb28"
+                    widgetDimensions="20px"
+                    widgetSpacings="0px"
+                  >
+                    <Ratings.Widget />
+                    <Ratings.Widget />
+                    <Ratings.Widget />
+                    <Ratings.Widget />
+                    <Ratings.Widget />
+                  </Ratings>
+                  <span style={styles.totalRating} title="Total ratings">
+                    {totalRating || 0}
+                  </span>
+                </Link>
               </div>
             </div>
             <div style={styles.row}>

--- a/src/components/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/SkillCardScrollList/SkillCardScrollList.js
@@ -170,21 +170,43 @@ class SkillCardScrollList extends Component {
             </div>
           </Link>
           <div style={styles.rating}>
-            <Ratings
-              rating={average_rating || 0}
-              widgetRatedColors="#ffbb28"
-              widgetDimensions="20px"
-              widgetSpacings="0px"
+            <Link
+              key={el}
+              to={{
+                pathname:
+                  '/' +
+                  skill.group +
+                  '/' +
+                  skill.skill_tag +
+                  '/' +
+                  this.props.languageValue +
+                  '/feedbacks',
+                state: {
+                  url: this.props.skillUrl,
+                  element: el,
+                  name: el,
+                  modelValue: this.props.modelValue,
+                  groupValue: skill.group,
+                  languageValue: this.props.languageValue,
+                },
+              }}
             >
-              <Ratings.Widget />
-              <Ratings.Widget />
-              <Ratings.Widget />
-              <Ratings.Widget />
-              <Ratings.Widget />
-            </Ratings>
-            <span style={styles.totalRating} title="Total ratings">
-              {total_rating || 0}
-            </span>
+              <Ratings
+                rating={average_rating || 0}
+                widgetRatedColors="#ffbb28"
+                widgetDimensions="20px"
+                widgetSpacings="0px"
+              >
+                <Ratings.Widget />
+                <Ratings.Widget />
+                <Ratings.Widget />
+                <Ratings.Widget />
+                <Ratings.Widget />
+              </Ratings>
+              <span style={styles.totalRating} title="Total ratings">
+                {total_rating || 0}
+              </span>
+            </Link>
           </div>
         </Card>,
       );


### PR DESCRIPTION
Fixes #1302 

Changes: Rating section on the skill cards should redirect to the feedback page for the skill. Why feedback page? -> https://github.com/fossasia/susi_skill_cms/issues/1302#issuecomment-407627152

Surge Deployment Link: https://pr-1304-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
NA