### PR TITLE
Fixes #1303: Fix the width of skill title on scroll card list

### DIFF
--- a/src/components/SkillCardScrollList/ScrollStyle.js
+++ b/src/components/SkillCardScrollList/ScrollStyle.js
@@ -39,6 +39,7 @@ const styles = {
     marginBottom: '6px',
     border: '1px',
     height: '20px',
+    width: 'fit-content',
   },
   example: {
     whiteSpace: 'normal',

--- a/src/components/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/SkillCardScrollList/SkillCardScrollList.js
@@ -165,10 +165,30 @@ class SkillCardScrollList extends Component {
                 <div style={styles.example}>&quot;{examples}&quot;</div>
               ) : null}
             </div>
-            <div style={styles.name}>
-              <span>{skill_name}</span>
-            </div>
           </Link>
+          <div style={styles.name}>
+            <Link
+              to={{
+                pathname:
+                  '/' +
+                  skill.group +
+                  '/' +
+                  skill.skill_tag +
+                  '/' +
+                  this.props.languageValue,
+                state: {
+                  url: this.props.skillUrl,
+                  element: el,
+                  name: el,
+                  modelValue: this.props.modelValue,
+                  groupValue: skill.group,
+                  languageValue: this.props.languageValue,
+                },
+              }}
+            >
+              <span>{skill_name}</span>
+            </Link>
+          </div>
           <div style={styles.rating}>
             <Ratings
               rating={average_rating || 0}


### PR DESCRIPTION
Fixes #1303 

Changes: Fix the width of the skill title so users can't click outside the title to visit the skill.


Surge Deployment Link: https://pr-1307-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43180927-59a2844e-8ff8-11e8-8a8f-906cffce8a8a.png)
