### PR TITLE
Fixes #1309: Update key for top games metrics as per server

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -346,7 +346,7 @@ export default class BrowseSkill extends React.Component {
           topUsedSkills: data.metrics.usage,
           latestSkills: data.metrics.latest,
           topFeedbackSkills: data.metrics.feedback,
-          topGames: data.metrics.topGames,
+          topGames: data.metrics['Games, Trivia and Accessories'],
         });
       },
       error: function(e) {


### PR DESCRIPTION
Fixes #1309 

Changes: Quick fix for updating the key for top games as per server.

Surge Deployment Link: https://pr-1316-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43241932-930b10de-90bb-11e8-96f0-0823da458921.png)
