### PR TITLE
Fetch skill's design using skill meta data API and remove access token

### DIFF
--- a/public/susi-chatbot.js
+++ b/public/susi-chatbot.js
@@ -1,4 +1,5 @@
 var susi_skills_deployed_url = "https://skills.susi.ai/";
+var api_url = "https://api.susi.ai";
 //Appending CSS
 var headTag = document.getElementsByTagName("head")[0];
 var link  = document.createElement('link');
@@ -14,7 +15,10 @@ link.href = susi_skills_deployed_url+'chat-style.css';
 link.media = 'all';
 headTag.appendChild(link);
 var script_tag = document.getElementById("susi-bot-script");
-var access_token = script_tag.getAttribute("data-token");
+var userid = script_tag.getAttribute("data-userid");
+var group = script_tag.getAttribute("data-group");
+var language = script_tag.getAttribute("data-language");
+var skill = script_tag.getAttribute("data-skill");
 var theme_settings = script_tag.getAttribute("data-theme")?script_tag.getAttribute("data-theme"):null;
 var botWindow = script_tag.getAttribute("data-bot-type")?(script_tag.getAttribute("data-bot-type")==="botWindow"?true:false):false;
 
@@ -56,23 +60,23 @@ function getTheme(){
 	else{
 		$.ajax({
 			type: "GET",
-			url: "https://api.susi.ai/aaa/listUserSettings.json?access_token="+access_token,
+			url: `${api_url}/cms/getSkillMetadata.json?userid=${userid}&group=${group}&language=${language}&skill=${skill}`,
 			jsonpCallback: 'pa',
 			contentType: "application/json",
 			dataType: 'jsonp',
 			jsonp: 'callback',
 			crossDomain: true,
 			success: function(data) {
-				if(data.settings){
-				let settings = data.settings;
-				botbuilderBackgroundBody = settings.botbuilderBackgroundBody?"#"+settings.botbuilderBackgroundBody:botbuilderBackgroundBody;
-				botbuilderBodyBackgroundImg = settings.botbuilderBodyBackgroundImg?settings.botbuilderBodyBackgroundImg:botbuilderBodyBackgroundImg;
-				botbuilderUserMessageBackground = settings.botbuilderUserMessageBackground?"#"+settings.botbuilderUserMessageBackground:botbuilderUserMessageBackground;
-				botbuilderUserMessageTextColor = settings.botbuilderUserMessageTextColor?"#"+settings.botbuilderUserMessageTextColor:botbuilderUserMessageTextColor;
-				botbuilderBotMessageBackground = settings.botbuilderBotMessageBackground?"#"+settings.botbuilderBotMessageBackground:botbuilderBotMessageBackground;
-				botbuilderBotMessageTextColor = settings.botbuilderBotMessageTextColor?"#"+settings.botbuilderBotMessageTextColor:botbuilderBotMessageTextColor;
-				botbuilderIconColor = settings.botbuilderIconColor?"#"+settings.botbuilderIconColor:botbuilderIconColor;
-				botbuilderIconImg = settings.botbuilderIconImg?settings.botbuilderIconImg:botbuilderIconImg;
+				if(data.skill_metadata && data.skill_metadata.design){
+				let settings = data.skill_metadata.design;
+				botbuilderBackgroundBody = settings.bodyBackground?settings.bodyBackground:botbuilderBackgroundBody;
+				botbuilderBodyBackgroundImg = settings.bodyBackgroundImage?settings.bodyBackgroundImage:botbuilderBodyBackgroundImg;
+				botbuilderUserMessageBackground = settings.userMessageBoxBackground?settings.userMessageBoxBackground:botbuilderUserMessageBackground;
+				botbuilderUserMessageTextColor = settings.userMessageTextColor?settings.userMessageTextColor:botbuilderUserMessageTextColor;
+				botbuilderBotMessageBackground = settings.botMessageBoxBackground?settings.botMessageBoxBackground:botbuilderBotMessageBackground;
+				botbuilderBotMessageTextColor = settings.botMessageTextColor?settings.botMessageTextColor:botbuilderBotMessageTextColor;
+				botbuilderIconColor = settings.botIconColor?settings.botIconColor:botbuilderIconColor;
+				botbuilderIconImg = settings.botIconImage?settings.botIconImage:botbuilderIconImg;
 				applyTheme();
 			}
 			},

--- a/src/components/Auth/Login/Login.js
+++ b/src/components/Auth/Login/Login.js
@@ -93,6 +93,7 @@ class Login extends Component {
             });
             console.log(cookies.get('serverUrl'));
             let accessToken = response.access_token;
+            let uuid = response.uuid;
             let state = this.state;
             let time = response.valid_seconds;
 
@@ -103,7 +104,7 @@ class Login extends Component {
             state.time = time;
             this.setState(state);
 
-            this.handleOnSubmit(email, accessToken, time);
+            this.handleOnSubmit(email, accessToken, uuid, time);
             let msg = 'You are logged in';
             state.msg = msg;
             this.setState(state);
@@ -169,10 +170,15 @@ class Login extends Component {
     this.setState(state);
   };
 
-  handleOnSubmit = (email, loggedIn, showAdmin, time) => {
+  handleOnSubmit = (email, loggedIn, uuid, time) => {
     let state = this.state;
     if (state.success) {
       cookies.set('loggedIn', loggedIn, {
+        path: '/',
+        maxAge: time,
+        domain: cookieDomain,
+      });
+      cookies.set('uuid', uuid, {
         path: '/',
         maxAge: time,
         domain: cookieDomain,

--- a/src/components/BotBuilder/BotBuilderPages/Deploy.js
+++ b/src/components/BotBuilder/BotBuilderPages/Deploy.js
@@ -1,9 +1,10 @@
 import React, { Component } from 'react';
 import Snackbar from 'material-ui/Snackbar';
+import PropTypes from 'prop-types';
 import Cookies from 'universal-cookie';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 const cookies = new Cookies();
-const host = window.location.protocol + '//' + window.location.host;
+const api = window.location.protocol + '//' + window.location.host;
 class Deploy extends Component {
   constructor() {
     super();
@@ -12,6 +13,7 @@ class Deploy extends Component {
     };
   }
   render() {
+    let { group, language, skill } = this.props;
     return (
       <div className="menu-page">
         <h1 style={{ lineHeight: '50px' }}>
@@ -22,16 +24,25 @@ class Deploy extends Component {
           <div className="code-box">
             <code>
               &lt;script type=&quot;text/javascript&quot;
-              id=&quot;susi-bot-script&quot; data-token=&quot;{cookies.get(
-                'loggedIn',
-              )}&quot; src=&quot;{host}/susi-chatbot.js&quot;&gt;&lt;/script&gt;
+              id=&quot;susi-bot-script&quot; data-userid=&quot;{cookies.get(
+                'uuid',
+              )}&quot; data-group=&quot;{group}&quot; data-language=&quot;{
+                language
+              }&quot; data-skill=&quot;{skill}&quot; src=&quot;{api}/susi-chatbot.js&quot;
+              &gt; &lt;/script&gt;
             </code>
             <CopyToClipboard
               text={
-                "<script type='text/javascript' id='susi-bot-script' data-token='" +
-                cookies.get('loggedIn') +
+                "<script type='text/javascript' id='susi-bot-script' data-userid='" +
+                cookies.get('uuid') +
+                "' data-group='" +
+                group +
+                "' data-language='" +
+                language +
+                "' data-skill='" +
+                skill +
                 "' src='" +
-                host +
+                api +
                 "/susi-chatbot.js'></script>"
               }
               onCopy={() => this.setState({ copied: true })}
@@ -57,4 +68,9 @@ class Deploy extends Component {
   }
 }
 
+Deploy.propTypes = {
+  group: PropTypes.string,
+  language: PropTypes.string,
+  skill: PropTypes.string,
+};
 export default Deploy;

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -212,7 +212,13 @@ class BotWizard extends React.Component {
           />
         );
       case 3:
-        return <Deploy />;
+        return (
+          <Deploy
+            group={this.state.groupValue}
+            language={this.state.languageValue}
+            skill={this.state.expertValue}
+          />
+        );
       default:
     }
   }


### PR DESCRIPTION
Fixes #1273 

Changes: 
- change the deployment code to remove the `access_token` and put `userid` and skill's `group`, `language`, and `skill`.
- fetch the chatbot's design settings from `getSkillMetaData.json` API by passing the above parameters.

Surge Deployment Link: https://pr-1317-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17807257/43245407-cc867d20-90cb-11e8-96de-1e02b55bef55.png)

