### PR TITLE
Correct error message on botbuilder if user is not logged in

### DIFF
--- a/src/components/BotBuilder/BotBuilderWrap.js
+++ b/src/components/BotBuilder/BotBuilderWrap.js
@@ -46,7 +46,7 @@ class BotBuilderWrap extends React.Component {
           <StaticAppBar {...this.props} />
           <div>
             <p style={styles.loggedInError}>
-              Please login to create the Contact Bot.
+              Please login to create a chatbot.
             </p>
           </div>
         </div>


### PR DESCRIPTION
Fixes #1319 

Changes: Simply corrected the error message.

Surge Deployment Link: https://pr-1320-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
<img width="1050" alt="screen shot 2018-07-26 at 3 32 03 pm" src="https://user-images.githubusercontent.com/31174685/43256033-1a557f48-90e9-11e8-904e-5eb12779d2ec.png">
