### PR TITLE
Remember user's choice between code view and UI view

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/Build.js
+++ b/src/components/BotBuilder/BotBuilderPages/Build.js
@@ -49,6 +49,25 @@ class Build extends Component {
 
   componentDidMount() {
     this.generateSkillData();
+    if (this.props.preferUiView === 'code') {
+      this.setState({
+        codeView: true,
+        conversationView: false,
+        treeView: false,
+      });
+    } else if (this.props.preferUiView === 'conversation') {
+      this.setState({
+        codeView: false,
+        conversationView: true,
+        treeView: false,
+      });
+    } else if (this.props.preferUiView === 'tree') {
+      this.setState({
+        codeView: false,
+        conversationView: false,
+        treeView: true,
+      });
+    }
   }
 
   sendInfoToProps = values => {
@@ -215,6 +234,7 @@ class Build extends Component {
                     conversationView: false,
                     treeView: false,
                   });
+                  this.props.onChangePreferUiView('code');
                 }}
                 disableTouchRipple={true}
               >
@@ -234,6 +254,7 @@ class Build extends Component {
                     conversationView: true,
                     treeView: false,
                   });
+                  this.props.onChangePreferUiView('conversation');
                 }}
                 disableTouchRipple={true}
               >
@@ -253,6 +274,7 @@ class Build extends Component {
                     conversationView: false,
                     treeView: true,
                   });
+                  this.props.onChangePreferUiView('tree');
                 }}
                 disableTouchRipple={true}
               >
@@ -309,6 +331,8 @@ Build.propTypes = {
   imageFile: PropTypes.object,
   image: PropTypes.string,
   imageUrl: PropTypes.string,
+  preferUiView: PropTypes.string,
+  onChangePreferUiView: PropTypes.func,
 };
 
 export default Build;

--- a/src/components/BotBuilder/BotBuilderPages/Configure.js
+++ b/src/components/BotBuilder/BotBuilderPages/Configure.js
@@ -30,6 +30,20 @@ class Configure extends Component {
     };
   }
 
+  componentDidMount() {
+    if (this.props.preferUiView === 'code') {
+      this.setState({
+        codeView: true,
+        uiView: false,
+      });
+    } else {
+      this.setState({
+        codeView: false,
+        uiView: true,
+      });
+    }
+  }
+
   sendInfoToProps = values => {
     this.props.updateConfiguration(values.code);
     this.setState({ ...values });
@@ -48,6 +62,7 @@ class Configure extends Component {
                   codeView: true,
                   uiView: false,
                 });
+                this.props.onChangePreferUiView('code');
               }}
               disableTouchRipple={true}
             >
@@ -66,6 +81,7 @@ class Configure extends Component {
                   codeView: false,
                   uiView: true,
                 });
+                this.props.onChangePreferUiView('ui');
               }}
               disableTouchRipple={true}
             >
@@ -103,5 +119,7 @@ class Configure extends Component {
 Configure.propTypes = {
   updateConfiguration: PropTypes.func,
   code: PropTypes.string,
+  preferUiView: PropTypes.string,
+  onChangePreferUiView: PropTypes.func,
 };
 export default Configure;

--- a/src/components/BotBuilder/BotBuilderPages/Design.js
+++ b/src/components/BotBuilder/BotBuilderPages/Design.js
@@ -16,6 +16,20 @@ class Design extends React.Component {
     };
   }
 
+  componentDidMount() {
+    if (this.props.preferUiView === 'code') {
+      this.setState({
+        codeView: true,
+        uiView: false,
+      });
+    } else {
+      this.setState({
+        codeView: false,
+        uiView: true,
+      });
+    }
+  }
+
   sendInfoToProps = values => {
     this.setState({ ...values });
   };
@@ -37,6 +51,7 @@ class Design extends React.Component {
                   codeView: true,
                   uiView: false,
                 });
+                this.props.onChangePreferUiView('code');
               }}
               disableTouchRipple={true}
             >
@@ -55,6 +70,7 @@ class Design extends React.Component {
                   codeView: false,
                   uiView: true,
                 });
+                this.props.onChangePreferUiView('ui');
               }}
               disableTouchRipple={true}
             >
@@ -100,6 +116,8 @@ class Design extends React.Component {
 Design.propTypes = {
   updateSettings: PropTypes.func,
   code: PropTypes.string,
+  preferUiView: PropTypes.string,
+  onChangePreferUiView: PropTypes.func,
 };
 
 export default Design;

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -83,6 +83,7 @@ class BotWizard extends React.Component {
       imageUrl: '',
       image: '',
       designData: null,
+      preferUiView: 'code',
       buildCode:
         '::name <Bot_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query',
       designCode:
@@ -237,6 +238,18 @@ class BotWizard extends React.Component {
     this.setState({ configCode: code });
   };
 
+  onChangePreferUiView = prefer => {
+    if (prefer === 'ui') {
+      if (this.state.preferUiView === 'code') {
+        this.setState({ preferUiView: 'conversation' });
+      } else {
+        return null;
+      }
+    } else {
+      this.setState({ preferUiView: prefer });
+    }
+  };
+
   getStepContent(stepIndex) {
     switch (stepIndex) {
       case 0:
@@ -248,6 +261,8 @@ class BotWizard extends React.Component {
             image={this.state.image}
             imageUrl={this.state.imageUrl}
             onImageChange={() => this.setState({ imageChanged: true })}
+            preferUiView={this.state.preferUiView}
+            onChangePreferUiView={this.onChangePreferUiView}
           />
         );
       case 1:
@@ -255,6 +270,8 @@ class BotWizard extends React.Component {
           <Design
             updateSettings={this.updateSettings}
             code={this.state.designCode}
+            preferUiView={this.state.preferUiView}
+            onChangePreferUiView={this.onChangePreferUiView}
           />
         );
       case 2:
@@ -262,6 +279,8 @@ class BotWizard extends React.Component {
           <Configure
             updateConfiguration={this.updateConfiguration}
             code={this.state.configCode}
+            preferUiView={this.state.preferUiView}
+            onChangePreferUiView={this.onChangePreferUiView}
           />
         );
       case 3:


### PR DESCRIPTION
Fixes #1293 

Changes:
- remember the user's choice between code view, conversation view, and tree view in the build tab.
- remember the user's choice between code view and UI view in other tabs.
- if the user chooses the code view in one of the tabs, all the tabs will show code view by default.
- if the user chooses the UI view in one of the tabs, all the tabs will show UI view by default.

Surge Deployment Link: https://pr-1353-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![remember choice user](https://user-images.githubusercontent.com/17807257/43361609-aee9ce94-92f0-11e8-97bf-95c1d3863df1.gif)