### PR TITLE
Show supported languages on skill page

### DIFF
--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -89,6 +89,7 @@ class SkillListing extends Component {
       feedbackMessage: '',
       editStatus: true,
       showDeleteDialog: false,
+      supportedLanguages: [],
     };
 
     let clickedSkill = this.props.location.pathname.split('/')[2];
@@ -439,6 +440,7 @@ class SkillListing extends Component {
       skillGroup: skillData.group,
       skillLanguage: skillData.language,
       skillTag: skillData.skill_tag,
+      supportedLanguages: skillData.supported_languages,
     });
   };
 
@@ -1033,6 +1035,25 @@ class SkillListing extends Component {
                     )}
                     <tr>
                       <td>Content Rating: </td> <td>4+ age</td>
+                    </tr>
+                    <tr>
+                      <td>Supported Languages: </td>
+                      <td>
+                        {this.state.supportedLanguages.map(languageObject => (
+                          <Link
+                            key={location.language}
+                            onClick={this.forceUpdate}
+                            to={`/${this.groupValue}/${languageObject.name}/${
+                              languageObject.language
+                            }`}
+                          >
+                            {ISO6391.getNativeName(languageObject.language)
+                              ? ISO6391.getNativeName(languageObject.language)
+                              : 'Universal'}
+                            &nbsp;
+                          </Link>
+                        ))}
+                      </td>
                     </tr>
                   </table>
                 </div>


### PR DESCRIPTION
Changes: 
Show list of supported languages on the skill page.

Surge Deployment Link: https://susi--cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/10573038/43366643-dac933c4-935e-11e8-9d49-5d346cad9ad3.png)
