### PR TITLE
Show instructions in deploy page step wise

### DIFF
--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -150,7 +150,7 @@ iframe{
 .bot-template-card:hover {
     -ms-transform: scale(1.02); /* IE 9 */
     -webkit-transform: scale(1.02); /* Safari 3-8 */
-	transform: scale(1.02); 
+	transform: scale(1.02);
 }
 
 .bot-delete {
@@ -225,6 +225,22 @@ input[type=file]{
 	text-align: center;
 	float: left;
 	cursor: pointer;
+}
+.deploy-steps li{
+	list-style-type: decimal;
+	font-size: 16px;
+	font-weight: bold;
+	margin-bottom: 20px;
+}
+.code-box{
+	font-size: 13px;
+	font-weight: normal;
+}
+.html-tag{
+	font-style: italic;
+	background-color: #eee;
+	display: inline-block;
+	padding: 0 3px;
 }
 
 @media (min-width:769px){

--- a/src/components/BotBuilder/BotBuilderPages/Deploy.js
+++ b/src/components/BotBuilder/BotBuilderPages/Deploy.js
@@ -14,47 +14,58 @@ class Deploy extends Component {
   }
   render() {
     let { group, language, skill } = this.props;
+    let part = ` data-skill=&quot;${skill}&quot; src=&quot;${api}/susi-chatbot.js&quot;`;
+    let code = `
+    &lt;script type=&quot;text/javascript&quot;
+    id=&quot;susi-bot-script&quot; data-userid=&quot;${cookies.get(
+      'uuid',
+    )}&quot; data-group=&quot;${group}&quot; data-language=&quot;${language}&quot;${part}
+    &gt;&lt;/script&gt;
+    `;
     return (
       <div className="menu-page">
         <h1 style={{ lineHeight: '50px' }}>
           4. Deploy your bot to your own website
         </h1>
         <br />
-        <div className="code-wrap show">
-          <div className="code-box">
-            <code>
-              &lt;script type=&quot;text/javascript&quot;
-              id=&quot;susi-bot-script&quot; data-userid=&quot;{cookies.get(
-                'uuid',
-              )}&quot; data-group=&quot;{group}&quot; data-language=&quot;{
-                language
-              }&quot; data-skill=&quot;{skill}&quot; src=&quot;{api}/susi-chatbot.js&quot;
-              &gt; &lt;/script&gt;
-            </code>
-            <CopyToClipboard
-              text={
-                "<script type='text/javascript' id='susi-bot-script' data-userid='" +
-                cookies.get('uuid') +
-                "' data-group='" +
-                group +
-                "' data-language='" +
-                language +
-                "' data-skill='" +
-                skill +
-                "' src='" +
-                api +
-                "/susi-chatbot.js'></script>"
-              }
-              onCopy={() => this.setState({ copied: true })}
-            >
-              <span className="copy-button">copy</span>
-            </CopyToClipboard>
-          </div>
-          <h4>
-            Paste the above code just above <i>&lt;/body&gt;</i>
-            &nbsp;tag in your website.
-          </h4>
-        </div>
+        <ol className="deploy-steps">
+          <li>
+            Add the code below to every page you want the Messenger to appear.
+            Copy and paste it before the{' '}
+            <span className="html-tag">&lt;body&gt;</span> tag on each page.
+            <br />
+            <br />
+            <div className="code-wrap show">
+              <div className="code-box">
+                <code dangerouslySetInnerHTML={{ __html: code }} />
+                <CopyToClipboard
+                  text={
+                    "<script type='text/javascript' id='susi-bot-script' data-userid='" +
+                    cookies.get('uuid') +
+                    "' data-group='" +
+                    group +
+                    "' data-language='" +
+                    language +
+                    "' data-skill='" +
+                    skill +
+                    "' src='" +
+                    api +
+                    "/susi-chatbot.js'></script>"
+                  }
+                  onCopy={() => this.setState({ copied: true })}
+                >
+                  <span className="copy-button">copy</span>
+                </CopyToClipboard>
+              </div>
+            </div>
+          </li>
+          <li>
+            Open your web app or website and look for the Messenger in the
+            bottom right corner.
+          </li>
+          <li>Start chatting with your SUSI bot.</li>
+        </ol>
+
         <Snackbar
           open={this.state.copied}
           message="Copied to clipboard!"


### PR DESCRIPTION
Fixes #1290

Changes: 
- show step wise instructions in the Deploy section, similar to intercom's one.

Surge Deployment Link: https://pr-1365-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17807257/43366966-17ba5480-9363-11e8-8b51-92fec5a0f913.png)