### PR TITLE
Fixes #1324: Add tooltips to skill groups on author skills component

### DIFF
--- a/src/components/AuthorSkills/AuthorSkills.js
+++ b/src/components/AuthorSkills/AuthorSkills.js
@@ -107,7 +107,7 @@ class AuthorSkills extends Component {
                     </a>
                   </div>
                 </TableRowColumn>
-                <TableRowColumn>{parse[4]}</TableRowColumn>
+                <TableRowColumn title={parse[4]}>{parse[4]}</TableRowColumn>
                 <TableRowColumn>
                   {ISO6391.getNativeName(parse[5])}
                 </TableRowColumn>


### PR DESCRIPTION
Fixes #1354 

Changes: Add a title attribute to skill category div, I know we're using react-tooltips lib in the project but this looked better to me.

Surge Deployment Link: https://pr-1366-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43376318-ac4ca5ca-93d7-11e8-99b3-1b78d69e5ca6.png)
