### PR TITLE
Fixes #1355: Add skill count and visited category/language name

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -1041,21 +1041,38 @@ export default class BrowseSkill extends React.Component {
                 this.state.ratingRefine ||
                 (this.state.timeFilter && this.state.skills.length) ? (
                   <div>
-                    {this.state.viewType === 'list' ? (
-                      <SkillCardList
-                        skills={this.state.skills}
-                        modelValue={this.state.modelValue}
-                        languageValue={this.state.languageValue}
-                        skillUrl={this.state.skillUrl}
-                      />
-                    ) : (
-                      <SkillCardGrid
-                        skills={this.state.skills}
-                        modelValue={this.state.modelValue}
-                        languageValue={this.state.languageValue}
-                        skillUrl={this.state.skillUrl}
-                      />
-                    )}
+                    <div
+                      style={{
+                        display: 'flex',
+                        margin: '0 0 10px 10px',
+                        fontSize: '16px',
+                      }}
+                    >
+                      {this.state.skills.length} results for&nbsp;<b>
+                        SUSI Skills
+                      </b>&nbsp;:&nbsp;<div
+                        style={{ color: '#4286f4', fontWeight: 'bold' }}
+                      >
+                        {this.props.routeValue}
+                      </div>
+                    </div>
+                    <div>
+                      {this.state.viewType === 'list' ? (
+                        <SkillCardList
+                          skills={this.state.skills}
+                          modelValue={this.state.modelValue}
+                          languageValue={this.state.languageValue}
+                          skillUrl={this.state.skillUrl}
+                        />
+                      ) : (
+                        <SkillCardGrid
+                          skills={this.state.skills}
+                          modelValue={this.state.modelValue}
+                          languageValue={this.state.languageValue}
+                          skillUrl={this.state.skillUrl}
+                        />
+                      )}
+                    </div>
                   </div>
                 ) : (
                   <div>


### PR DESCRIPTION
Fixes #1355 

Changes: Add skill count of the visited category/language and also show their name like alexa.

Surge Deployment Link: https://pr-1367-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43377174-f0512ebc-93dc-11e8-9b5b-cf2d12548f65.png)
