### PR TITLE
Fixed the console errors due to use of invalid prop type

### DIFF
--- a/src/components/SkillCardGrid/SkillCardGrid.js
+++ b/src/components/SkillCardGrid/SkillCardGrid.js
@@ -173,7 +173,7 @@ class SkillCardGrid extends Component {
 
 SkillCardGrid.propTypes = {
   skills: PropTypes.array,
-  languageValue: PropTypes.string,
+  languageValue: PropTypes.array,
   skillUrl: PropTypes.string,
   modelValue: PropTypes.string,
 };


### PR DESCRIPTION
Fixes #1371 

Changes: Fixed the console errors due to use of invalid prop type. `languageValue` in the `SkillCardGrid.js` component has correct prop type now.

Surge Deployment Link: https://pr-1372-fossasia-susi-skill-cms.surge.sh
