### PR TITLE
Changed dropdowns to checkbox while changing status of any Skill from Admin panel

### DIFF
--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -3,8 +3,7 @@ import Table from 'antd/lib/table';
 import FlatButton from 'material-ui/FlatButton';
 import Dialog from 'material-ui/Dialog';
 import enUS from 'antd/lib/locale-provider/en_US';
-import DropDownMenu from 'material-ui/DropDownMenu';
-import MenuItem from 'material-ui/MenuItem';
+import Checkbox from 'material-ui/Checkbox';
 import CircularProgress from 'material-ui/CircularProgress';
 import Snackbar from 'material-ui/Snackbar';
 import Cookies from 'universal-cookie';
@@ -30,7 +29,7 @@ class ListSkills extends React.Component {
       isAction: false,
       showDialog: false,
       skillName: '',
-      skill_tag: '',
+      skillTag: '',
       skillModel: '',
       skillGroup: '',
       skillLanguage: '',
@@ -66,7 +65,7 @@ class ListSkills extends React.Component {
       `/cms/changeSkillStatus.json?model=${this.state.skillModel}&group=${
         this.state.skillGroup
       }&language=${this.state.skillLanguage}&skill=${
-        this.state.skill_tag
+        this.state.skillTag
       }&reviewed=${this.state.skillReviewStatus}&editable=${
         this.state.skillEditStatus
       }&access_token=` +
@@ -233,7 +232,7 @@ class ListSkills extends React.Component {
             model: i.model,
             group: i.group,
             language: i.language,
-            skill_tag: i.skill_tag,
+            skillTag: i.skill_tag,
             reviewStatus: i.reviewed,
             editStatus: i.editable,
             type: 'public',
@@ -312,14 +311,14 @@ class ListSkills extends React.Component {
     language,
     reviewStatus,
     editStatus,
-    skill_tag,
+    skillTag,
   ) => {
     this.setState({
       skillModel: model,
       skillGroup: group,
       skillLanguage: language,
       skillName: name,
-      skill_tag: skill_tag,
+      skillTag: skillTag,
       skillReviewStatus: reviewStatus,
       skillEditStatus: editStatus,
       showDialog: true,
@@ -334,13 +333,15 @@ class ListSkills extends React.Component {
     });
   };
 
-  handleReviewStatusChange = (event, index, value) => {
+  handleReviewStatusChange = () => {
+    let value = !this.state.skillReviewStatus;
     this.setState({
       skillReviewStatus: value,
     });
   };
 
-  handleEditStatusChange = (event, index, value) => {
+  handleEditStatusChange = () => {
+    let value = !this.state.skillEditStatus;
     this.setState({
       skillEditStatus: value,
     });
@@ -355,7 +356,7 @@ class ListSkills extends React.Component {
       <FlatButton
         key={1}
         label="Change"
-        primary={true}
+        labelStyle={{ color: '#4285f4' }}
         onTouchTap={this.handleChange}
       />,
       <FlatButton
@@ -370,7 +371,7 @@ class ListSkills extends React.Component {
       <FlatButton
         key={1}
         label="Delete"
-        primary={true}
+        labelStyle={{ color: '#4285f4' }}
         onTouchTap={this.confirmDelete}
       />,
       <FlatButton
@@ -385,7 +386,7 @@ class ListSkills extends React.Component {
       <FlatButton
         key={1}
         label="Restore"
-        primary={true}
+        labelStyle={{ color: '#4285f4' }}
         onTouchTap={this.confirmRestore}
       />,
       <FlatButton
@@ -395,10 +396,6 @@ class ListSkills extends React.Component {
         onTouchTap={this.handleClose}
       />,
     ];
-
-    const blueThemeColor = { color: 'rgb(66, 133, 244)' };
-    const themeForegroundColor = '#272727';
-    const themeBackgroundColor = '#fff';
 
     let columns = [
       {
@@ -586,76 +583,43 @@ class ListSkills extends React.Component {
             >
               <TabPane tab="Active" key="1">
                 <Dialog
-                  title="Skill Settings"
+                  title={'Skill Settings for ' + this.state.skillName}
                   actions={actions}
                   model={true}
                   open={this.state.showDialog}
+                  style={{
+                    width: '800px',
+                    left: '50%',
+                    marginLeft: '-400px',
+                  }}
                 >
                   <div>
-                    Change the review status of skill {this.state.skillName}
-                  </div>
-                  <div>
-                    <DropDownMenu
-                      selectedMenuItemStyle={blueThemeColor}
-                      onChange={this.handleReviewStatusChange}
-                      value={this.state.skillReviewStatus}
-                      labelStyle={{ color: themeForegroundColor }}
-                      menuStyle={{
-                        backgroundColor: themeBackgroundColor,
-                      }}
-                      menuItemStyle={{
-                        color: themeForegroundColor,
-                      }}
+                    <Checkbox
+                      label="Reviewed"
+                      labelPosition="right"
+                      className="select"
+                      checked={this.state.skillReviewStatus}
+                      labelStyle={{ fontSize: '14px' }}
+                      iconStyle={{ left: '4px', fill: '#4285f4' }}
                       style={{
-                        width: '250px',
-                        marginLeft: '-20px',
+                        width: 'auto',
+                        marginTop: '3px',
                       }}
-                      autoWidth={false}
-                    >
-                      <MenuItem
-                        primaryText="Approved"
-                        value={true}
-                        className="setting-item"
-                      />
-                      <MenuItem
-                        primaryText="Not Approved"
-                        value={false}
-                        className="setting-item"
-                      />
-                    </DropDownMenu>
-                  </div>
-                  <div style={{ marginTop: '12px' }}>
-                    Change the edit status of skill {this.state.skillName}
-                  </div>
-                  <div>
-                    <DropDownMenu
-                      selectedMenuItemStyle={blueThemeColor}
-                      onChange={this.handleEditStatusChange}
-                      value={this.state.skillEditStatus}
-                      labelStyle={{ color: themeForegroundColor }}
-                      menuStyle={{
-                        backgroundColor: themeBackgroundColor,
-                      }}
-                      menuItemStyle={{
-                        color: themeForegroundColor,
-                      }}
+                      onCheck={this.handleReviewStatusChange}
+                    />
+                    <Checkbox
+                      label="Editable"
+                      labelPosition="right"
+                      className="select"
+                      checked={this.state.skillEditStatus}
+                      labelStyle={{ fontSize: '14px' }}
+                      iconStyle={{ left: '4px', fill: '#4285f4' }}
                       style={{
-                        width: '250px',
-                        marginLeft: '-20px',
+                        width: 'auto',
+                        marginTop: '3px',
                       }}
-                      autoWidth={false}
-                    >
-                      <MenuItem
-                        primaryText="Editable"
-                        value={true}
-                        className="setting-item"
-                      />
-                      <MenuItem
-                        primaryText="Not Editable"
-                        value={false}
-                        className="setting-item"
-                      />
-                    </DropDownMenu>
+                      onCheck={this.handleEditStatusChange}
+                    />
                   </div>
                 </Dialog>
 
@@ -685,7 +649,7 @@ class ListSkills extends React.Component {
                     <FlatButton
                       key={1}
                       label="Ok"
-                      primary={true}
+                      labelStyle={{ color: '#4285f4' }}
                       onTouchTap={this.handleFinish}
                     />
                   }
@@ -711,7 +675,7 @@ class ListSkills extends React.Component {
                     <FlatButton
                       key={1}
                       label="Ok"
-                      primary={true}
+                      labelStyle={{ color: '#4285f4' }}
                       onTouchTap={this.handleFinish}
                     />
                   }
@@ -737,7 +701,7 @@ class ListSkills extends React.Component {
                     <FlatButton
                       key={1}
                       label="Ok"
-                      primary={true}
+                      labelStyle={{ color: '#4285f4' }}
                       onTouchTap={this.handleFinish}
                     />
                   }
@@ -763,7 +727,7 @@ class ListSkills extends React.Component {
                     <FlatButton
                       key={1}
                       label="Ok"
-                      primary={true}
+                      labelStyle={{ color: '#4285f4' }}
                       onTouchTap={this.handleFinish}
                     />
                   }
@@ -790,7 +754,7 @@ class ListSkills extends React.Component {
                     <FlatButton
                       key={1}
                       label="Ok"
-                      primary={true}
+                      labelStyle={{ color: '#4285f4' }}
                       onTouchTap={this.handleFinish}
                     />
                   }
@@ -816,7 +780,7 @@ class ListSkills extends React.Component {
                     <FlatButton
                       key={1}
                       label="Ok"
-                      primary={true}
+                      labelStyle={{ color: '#4285f4' }}
                       onTouchTap={this.handleFinish}
                     />
                   }

--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -74,7 +74,7 @@ export default class ListUser extends Component {
           return (
             <span>
               <div
-                style={{ cursor: 'pointer', color: '#49A9EE' }}
+                style={{ cursor: 'pointer', color: '#4285f4' }}
                 onClick={() => this.editUserRole(record.email, record.userRole)}
               >
                 Edit
@@ -287,7 +287,7 @@ export default class ListUser extends Component {
       <FlatButton
         key={1}
         label="Change"
-        primary={true}
+        labelStyle={{ color: '#4285f4' }}
         onTouchTap={this.handleChange}
       />,
       <FlatButton
@@ -365,7 +365,7 @@ export default class ListUser extends Component {
               <FlatButton
                 key={1}
                 label="Ok"
-                primary={true}
+                labelStyle={{ color: '#4285f4' }}
                 onTouchTap={this.handleSuccess}
               />
             }


### PR DESCRIPTION
Fixes #1391 
Fixes #1287 

Changes: Changed dropdowns to checkbox while changing status of any Skill from Admin panel.
Checkbox seem to be a better choice as all choices in the `Edit` dialog box would be a `true` or `false` type of choice. This would also make the UI look better when more options like `Staff Picks` or `Enabled` are added to the dialog box.

Surge Deployment Link: https://pr-1392-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

<img width="1440" alt="screen shot 2018-07-31 at 11 01 49 pm" src="https://user-images.githubusercontent.com/31135861/43476257-c0a2f594-9515-11e8-9e5a-65f9cf167f77.png">