### PR TITLE
Extract correct configure code and prefill skill identifiers in editing private skill

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -112,7 +112,10 @@ class BotWizard extends React.Component {
           '::bodyBackground ' +
           text.split('::bodyBackground ')[1].split('::name')[0];
         let configCode =
-          '!Write' + text.split('!Write')[1].split('::bodyBackground')[0];
+          '::allow_bot_only_on_own_sites' +
+          text
+            .split('::allow_bot_only_on_own_sites')[1]
+            .split('::bodyBackground')[0];
         const imageNameMatch = buildCode.match(/^::image\s(.*)$/m);
         let imagePreviewUrl = `${
           urls.API_URL
@@ -135,13 +138,21 @@ class BotWizard extends React.Component {
             imageUrl: imageNameMatch[1],
             updateSkillNow: true,
             savedSkillOld,
+            groupValue: group,
+            languageValue: language,
+            expertValue: name,
           },
           () => this.generateDesignData(),
         );
       }.bind(this),
       error: function(err) {
         console.log(err);
-      },
+        this.setState({
+          loaded: true,
+          msgSnackbar: "Error! Couldn't fetch skill",
+          openSnackbar: true,
+        });
+      }.bind(this),
     });
   };
 


### PR DESCRIPTION
Fixes #1390 

Changes: 
- Extract the full configure code from the skill which is fetched in the `getSkill.json` API. Earlier, the first line of the code was not being extracted, which was causing the error.
- Save the skill's identifier (`group`, `language`, `name`) when the  `getSkill.json` API is called. This will pass the correct values to the Deploy section, which was showing `null` before.

Surge Deployment Link: https://pr-1393-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17807257/43472397-fbbf8e0e-950a-11e8-85d6-5027d6008b82.png)

![image](https://user-images.githubusercontent.com/17807257/43472379-f3e446ac-950a-11e8-8fff-dc5b3af04d38.png)
