### PR TITLE
Persistent language filter

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -36,6 +36,8 @@ import _ from 'lodash';
 import Ratings from 'react-ratings-declarative';
 
 import './custom.css';
+import Cookies from 'universal-cookie';
+const cookies = new Cookies();
 
 let groups = [];
 let languages = [];
@@ -74,7 +76,7 @@ export default class BrowseSkill extends React.Component {
       modelValue: 'general',
       skillURL: null,
       groupValue: 'All',
-      languageValue: ['en'],
+      languageValue: cookies.get('languages') || ['en'],
       showSkills: '',
       showReviewedSkills: false,
       expertValue: null,
@@ -133,6 +135,7 @@ export default class BrowseSkill extends React.Component {
   };
 
   handleLanguageChange = (event, index, values) => {
+    cookies.set('languages', values);
     this.setState({ languageValue: values }, function() {
       this.loadCards();
     });

--- a/src/components/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/SkillCardScrollList/SkillCardScrollList.js
@@ -142,7 +142,7 @@ class SkillCardScrollList extends Component {
                 '/' +
                 skill.skill_tag +
                 '/' +
-                this.props.languageValue,
+                skill.language,
               state: {
                 url: this.props.skillUrl,
                 element: el,


### PR DESCRIPTION
Fixes #1399 

Changes:
Added language filter to cookies that make it persistent over the CMS.

Surge Deployment Link: https://susi--cms.surge.sh

Screenshots for the change:
NA