### PR TITLE
Implement fetching response for user query on chatbot as per private skill

### DIFF
--- a/public/susi-chatbot.js
+++ b/public/susi-chatbot.js
@@ -246,12 +246,16 @@ function enableBot() {
 
 		// Send request to SUSI API
 		function send(text) {
+			let url = baseUrl+encodeURIComponent(text);
+			if(userid && group && language && skill){
+				url += `&privateskill=1&userid=${userid}&group=${group}&language=${language}&skill=${skill}`;
+			}
 			var thisMsgNumber = msgNumber;
 			msgNumber++;
 			setLoadingMessage(thisMsgNumber);
 			$.ajax({
 				type: "GET",
-				url: baseUrl+encodeURIComponent(text),
+				url: url,
 				contentType: "application/json",
 				dataType: "json",
 				success: function(data) {

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -48,7 +48,13 @@ class BotWizard extends React.Component {
         let name = this.getQueryStringValue('name');
         let group = this.getQueryStringValue('group');
         let language = this.getQueryStringValue('language');
-        this.setState({ commitMessage: `Updated Skill ${name}` });
+        this.setState({
+          commitMessage: `Updated Skill ${name}`,
+          newBot: false,
+          skillName: name,
+          skillGroup: group,
+          skillLanguage: language,
+        });
         this.getBotDetails(name, group, language);
       }
     } else {
@@ -84,6 +90,10 @@ class BotWizard extends React.Component {
       image: '',
       designData: null,
       preferUiView: 'code',
+      newBot: true,
+      skillName: '',
+      skillGroup: '',
+      skillLanguage: '',
       buildCode:
         '::name <Bot_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image <image_url>\n::terms_of_use <link>\n\n\nUser query1|query2|quer3....\n!example:<The question that should be shown in public skill displays>\n!expect:<The answer expected for the above example>\nAnswer for the user query',
       designCode:
@@ -414,12 +424,18 @@ class BotWizard extends React.Component {
             OldSkill: self.state.expertValue.trim().replace(/\s/g, '_'),
             old_image_name: self.state.imageUrl.replace('images/', ''),
           };
-          self.setState({
-            savingSkill: false,
-            savedSkillOld,
-            updateSkillNow: true,
-            imageChanged: false,
-          });
+          self.setState(
+            {
+              savingSkill: false,
+              savedSkillOld,
+              updateSkillNow: true,
+              imageChanged: false,
+              skillName: savedSkillOld.OldSkill,
+              skillGroup: savedSkillOld.OldGroup,
+              skillLanguage: savedSkillOld.OldLanguage,
+            },
+            () => self.handleNext(),
+          );
           notification.open({
             message: 'Accepted',
             description: 'Your Skill has been saved',
@@ -446,7 +462,6 @@ class BotWizard extends React.Component {
           icon: <Icon type="close-circle" style={{ color: '#f44336' }} />,
         });
       });
-    this.handleNext();
   };
 
   render() {
@@ -633,7 +648,14 @@ class BotWizard extends React.Component {
                       marginTop: '20px',
                     }}
                   >
-                    <Preview designData={this.state.designData} />
+                    <Preview
+                      designData={this.state.designData}
+                      newBot={this.state.newBot}
+                      isDeployed={this.state.updateSkillNow}
+                      skillName={this.state.skillName}
+                      skillGroup={this.state.skillGroup}
+                      skillLanguage={this.state.skillLanguage}
+                    />
                   </div>
                 </Paper>
               </Col>

--- a/src/components/BotBuilder/Preview/Preview.js
+++ b/src/components/BotBuilder/Preview/Preview.js
@@ -2,9 +2,11 @@ import React, { Component } from 'react';
 import $ from 'jquery';
 import urls from '../../../utils/urls';
 import PropTypes from 'prop-types';
+import Cookies from 'universal-cookie';
 import './Chatbot.css';
 import './Preview.css';
 
+const cookies = new Cookies();
 const host = window.location.protocol + '//' + window.location.host;
 class Preview extends Component {
   constructor() {
@@ -155,12 +157,19 @@ class Preview extends Component {
 
   // Send request to SUSI API
   send = text => {
+    let url = urls.API_URL + '/susi/chat.json?q=' + encodeURIComponent(text);
+    if (!this.props.newBot || this.props.isDeployed) {
+      let userid = cookies.get('uuid');
+      url += `&privateskill=1&userid=${userid}&group=${
+        this.props.skillGroup
+      }&language=${this.props.skillLanguage}&skill=${this.props.skillName}`;
+    }
     var thisMsgNumber = this.msgNumber;
     this.msgNumber++;
     this.setLoadingMessage(thisMsgNumber);
     $.ajax({
       type: 'GET',
-      url: urls.API_URL + '/susi/chat.json?q=' + encodeURIComponent(text),
+      url: url,
       contentType: 'application/json',
       dataType: 'json',
       success: function(data) {
@@ -345,5 +354,10 @@ class Preview extends Component {
 
 Preview.propTypes = {
   designData: PropTypes.object,
+  newBot: PropTypes.bool,
+  isDeployed: PropTypes.bool,
+  skillName: PropTypes.string,
+  skillGroup: PropTypes.string,
+  skillLanguage: PropTypes.string,
 };
 export default Preview;


### PR DESCRIPTION
Fixes #1339 

Changes: Changed API call url to implement fetching response for user query on chatbot as per private skill

If my skill is:
<img width="395" alt="screen shot 2018-08-01 at 6 50 33 pm" src="https://user-images.githubusercontent.com/31174685/43524138-1a51c524-95bc-11e8-8929-e057e318aaf9.png">


Then here's a conversation with chatbot:
<img width="212" alt="screen shot 2018-08-01 at 6 50 19 pm" src="https://user-images.githubusercontent.com/31174685/43524142-1bf6cd5c-95bc-11e8-9435-a88da3e8d428.png">

Also, you can see the skill in preview when editing a saved chatbot:
<img width="1438" alt="screen shot 2018-08-01 at 7 22 42 pm" src="https://user-images.githubusercontent.com/31174685/43526022-e2256890-95c0-11e8-99cf-930b1454610d.png">


Surge Deployment Link: https://pr-1405-fossasia-susi-skill-cms.surge.sh

