### PR TITLE
Fixes #1418: Add default text when country wise data is not available

### DIFF
--- a/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.css
+++ b/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.css
@@ -24,3 +24,8 @@
         width: 100%;
     }
 }
+
+.unavailable-message {
+    display: flex;
+    justify-content: center;
+}

--- a/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.js
+++ b/src/components/CountryWiseSkillUsageCard/CountryWiseSkillUsageCard.js
@@ -15,12 +15,13 @@ class CountryWiseSkillUsageCard extends PureComponent {
       return isoCountries[countryCode];
     }
   };
-  countryUsageList = props => {
+  countryUsageList = () => {
+    const { countryWiseSkillUsage } = this.props;
     return (
       <Table>
         <TableBody displayRowCheckbox={false}>
-          {this.props.country_wise_skill_usage &&
-            this.props.country_wise_skill_usage.map((data, id) => {
+          {countryWiseSkillUsage &&
+            countryWiseSkillUsage.map((data, id) => {
               let countryCode = data[0];
               let usage = data[1];
               let countryName = this.getCountryName(countryCode);
@@ -43,19 +44,28 @@ class CountryWiseSkillUsageCard extends PureComponent {
   };
 
   render() {
+    const { countryWiseSkillUsage } = this.props;
     return (
-      <div className="country-usage-container">
-        <div className="country-usage-graph">
-          <GeoChart data={this.props.country_wise_skill_usage} />
-        </div>
-        <div className="country-usage-list">{this.countryUsageList()}</div>
+      <div>
+        {countryWiseSkillUsage && countryWiseSkillUsage.length ? (
+          <div className="country-usage-container">
+            <div className="country-usage-graph">
+              <GeoChart data={countryWiseSkillUsage} />
+            </div>
+            <div className="country-usage-list">{this.countryUsageList()}</div>
+          </div>
+        ) : (
+          <div className="unavailable-message">
+            Country wise usage distribution is not available.
+          </div>
+        )}
       </div>
     );
   }
 }
 
 CountryWiseSkillUsageCard.propTypes = {
-  country_wise_skill_usage: PropTypes.array,
+  countryWiseSkillUsage: PropTypes.array,
 };
 
 export default CountryWiseSkillUsageCard;

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -77,7 +77,7 @@ class SkillListing extends Component {
       total_star: 0,
       skill_ratings: [],
       skill_usage: [],
-      country_wise_skill_usage: [],
+      countryWiseSkillUsage: [],
       rating: 0,
       openSnack: false,
       snackMessage: '',
@@ -337,15 +337,15 @@ class SkillListing extends Component {
     });
   };
 
-  saveCountryWiseSkillUsage = (country_wise_skill_usage = []) => {
+  saveCountryWiseSkillUsage = (countryWiseSkillUsage = []) => {
     // Add sample data to test
-    let data = country_wise_skill_usage.map(country => [
+    let data = countryWiseSkillUsage.map(country => [
       country.country_code,
       parseInt(country.count, 10),
     ]);
 
     this.setState({
-      country_wise_skill_usage: data,
+      countryWiseSkillUsage: data,
     });
   };
 
@@ -1080,7 +1080,7 @@ class SkillListing extends Component {
             <SkillUsageCard
               skill_usage={this.state.skill_usage}
               device_usage_data={this.state.device_usage_data}
-              country_wise_skill_usage={this.state.country_wise_skill_usage}
+              countryWiseSkillUsage={this.state.countryWiseSkillUsage}
             />
           </div>
         </div>

--- a/src/components/SkillUsageCard/SkillUsageCard.js
+++ b/src/components/SkillUsageCard/SkillUsageCard.js
@@ -130,24 +130,18 @@ class SkillUsageCard extends Component {
               ) : (
                 ''
               )}
-              {this.props.country_wise_skill_usage !== [] ? (
-                <div className="device-usage">
-                  <div className="sub-title">Country wise Usage</div>
-                  <CountryWiseSkillUsageCard
-                    country_wise_skill_usage={
-                      this.props.country_wise_skill_usage
-                    }
-                  />
-                </div>
-              ) : (
-                ''
-              )}
             </div>
           ) : (
             <div className="default-message">
               No usage data available, try this skill now!
             </div>
           )}
+          <div className="device-usage">
+            <div className="sub-title">Country wise Usage</div>
+            <CountryWiseSkillUsageCard
+              countryWiseSkillUsage={this.props.countryWiseSkillUsage}
+            />
+          </div>
         </Paper>
       </div>
     );
@@ -244,7 +238,7 @@ renderActiveShape.propTypes = {
 SkillUsageCard.propTypes = {
   skill_usage: PropTypes.array,
   device_usage_data: PropTypes.array,
-  country_wise_skill_usage: PropTypes.array,
+  countryWiseSkillUsage: PropTypes.array,
 };
 
 export default SkillUsageCard;


### PR DESCRIPTION
Fixes #1418 

Changes: Default text for country wise skill usage data.

Surge Deployment Link: https://pr-1419-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43586566-98648b6c-9685-11e8-9b45-e61ad3fc1824.png)
