### PR TITLE
Fixes #1417: UI fixes in the heading on skill history page

### DIFF
--- a/src/components/SkillVersion/SkillVersion.js
+++ b/src/components/SkillVersion/SkillVersion.js
@@ -1,6 +1,9 @@
+// Packages
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+
+// Material-UI
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import {
   Table,
@@ -14,6 +17,8 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 import { RaisedButton } from 'material-ui';
 import CircularProgress from 'material-ui/CircularProgress';
 import { RadioButton } from 'material-ui/RadioButton';
+
+// Other Utils
 import notification from 'antd/lib/notification';
 import Icon from 'antd/lib/icon';
 import $ from 'jquery';
@@ -293,8 +298,11 @@ class SkillVersion extends Component {
         ) : (
           <div className="skill_listing_container" style={styles.home}>
             <div className="margin-b-md margin-t-md skill">
-              <h1 className="title">
-                {this.state.skillMeta.skillName + ' : '}Revision History
+              <h1 style={{ display: 'flex' }}>
+                <div style={{ textTransform: 'capitalize' }}>
+                  {this.state.skillMeta.skillName.split('_').join(' ')}
+                </div>
+                &nbsp;:&nbsp;Revision History
               </h1>
               <p>
                 <span>


### PR DESCRIPTION
Fixes #1417 
Changes: Skill heading UI updates

Surge Deployment Link: https://pr-1420-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43587616-39eeba64-9688-11e8-9fbc-ddc0faabefcb.png)
