### PR TITLE
Fixes #1424: UI updates in skill history page

### DIFF
--- a/src/components/SkillHistory/SkillHistory.js
+++ b/src/components/SkillHistory/SkillHistory.js
@@ -191,7 +191,7 @@ class SkillHistory extends Component {
     const compareBtnStyle = {
       margin: '20px',
       position: 'absolute',
-      right: '12',
+      right: '24',
       top: '70',
     };
     let rightEditorWidth = '50%';
@@ -216,16 +216,28 @@ class SkillHistory extends Component {
                 <div>
                   <div>
                     Currently Viewing :{' '}
-                    <a href="../../../en">
+                    <Link
+                      to={{
+                        pathname:
+                          '/' +
+                          this.state.skillMeta.groupValue +
+                          '/' +
+                          this.state.skillMeta.skillName +
+                          '/' +
+                          this.state.skillMeta.languageValue,
+                      }}
+                    >
                       <RaisedButton
                         label="Back"
                         backgroundColor={colors.header}
                         labelColor="#fff"
                         style={compareBtnStyle}
                       />
-                    </a>
+                    </Link>
                   </div>
-                  <h3>{this.state.skillMeta.skillName}</h3>
+                  <h3 style={{ textTransform: 'capitalize' }}>
+                    {this.state.skillMeta.skillName.split('_').join(' ')}
+                  </h3>
                 </div>
               </Paper>
               <div className="version-code-left">


### PR DESCRIPTION
Fixes #1424 

Changes: Use `Link`, fix margin accross back button, transform skill name.

Surge Deployment Link: https://pr-1427-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43632629-4edefaa0-9724-11e8-9a65-fffb4b3c549c.png)
