### PR TITLE
Put border on whole of ace editor

### DIFF
--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -227,11 +227,11 @@ input[type=file]{
 	cursor: pointer;
 }
 
-.ace_scroller {
+.ace_editor {
 	border: 1px solid #d1d5da;
 	background-color: #fafbfc !important; /* csslint allow: known-properties, important */
 }
-.ace_focus .ace_scroller{
+.ace_focus {
 	background-color: #ffffff !important; /* csslint allow: known-properties, important */
 	border-color: #2188ff;
 	box-shadow: inset 0 1px 2px rgba(27,31,35,0.075), 0 0 0 0.2em rgba(3,102,214,0.3);


### PR DESCRIPTION
Fixes #1437

Changes: 
- remove border from inside of the ace editor and put it outside, on the whole of ace editor, similar to github's editor.

Surge Deployment Link: https://pr-1442-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17807257/43672236-65c00158-97c7-11e8-9ae4-87f179d15e4d.png)

