### PR TITLE
Fixes #1445: Do not allow decimals in skill usage line chart

### DIFF
--- a/src/components/SkillUsageCard/SkillUsageCard.js
+++ b/src/components/SkillUsageCard/SkillUsageCard.js
@@ -81,7 +81,7 @@ class SkillUsageCard extends Component {
                       }}
                     >
                       <XAxis dataKey="date" padding={{ right: 20 }} />
-                      <YAxis />
+                      <YAxis allowDecimals={false} />
                       <Tooltip wrapperStyle={{ height: '60px' }} />
                       <Legend />
                       <Line


### PR DESCRIPTION
Fixes #1445 

Changes: Set allowDecimals prop to false.

Surge Deployment Link: https://pr-1446-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/43673109-613b924c-97da-11e8-9bb1-a117d17065ba.png)
