### PR TITLE
Fix bug with changing from code view to UI view putting a blank entry in table

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/ConfigureViews/UIView.js
+++ b/src/components/BotBuilder/BotBuilderPages/ConfigureViews/UIView.js
@@ -125,7 +125,9 @@ class UIView extends Component {
       name: websiteName,
       date: date.toString(),
     };
-    this.dataSource = [...this.dataSource, newData];
+    if (newData.name !== '') {
+      this.dataSource = [...this.dataSource, newData];
+    }
   };
 
   handleSave = row => {

--- a/src/components/SkillCreator/SkillCreator.js
+++ b/src/components/SkillCreator/SkillCreator.js
@@ -916,9 +916,8 @@ const styles = {
     paddingTop: '10px',
   },
   helpIcon: {
-    position: 'absolute',
-    top: '150px',
-    right: '43px',
+    position: 'relative',
+    float: 'right',
     height: '20px',
     width: '20px',
     cursor: 'pointer',


### PR DESCRIPTION
Fixes #1455 

Changes: Earlier, changing from code view to UI view in configure tab while having `allow_bot_only_on_own_sites` as `yes` was putting a blank entry in the table. Fixed this bug.
Also, fixed another minor bug with position of info icon in SkillCreator.

Surge Deployment Link: https://pr-1457-fossasia-susi-skill-cms.surge.sh
