### PR TITLE
Prefill the available code

### DIFF
--- a/src/components/SkillCreator/SkillCreator.js
+++ b/src/components/SkillCreator/SkillCreator.js
@@ -109,6 +109,55 @@ export default class SkillCreator extends Component {
       this.setState({ loadViews: true });
     }
     this.generateSkillData();
+    this.prefillCode();
+  };
+
+  prefillCode = () => {
+    if (cookies.get('username')) {
+      const code = this.state.code.replace(
+        /^::author\s(.*)$/m,
+        '::author ' + cookies.get('username'),
+      );
+
+      this.setState(
+        {
+          code,
+        },
+        () => this.handleReload(),
+      );
+    }
+
+    if (cookies.get('emailId')) {
+      $.ajax({
+        url: 'https://api.github.com/search/users?q=' + cookies.get('emailId'),
+        dataType: 'jsonp',
+        jsonp: 'callback',
+        crossDomain: true,
+        success: function(data) {
+          if (data.data.items) {
+            data = data.data.items;
+            for (let i = 0; i < data.length; i++) {
+              if (data[i].type === 'User') {
+                const code = this.state.code.replace(
+                  /^::author_url\s(.*)$/m,
+                  '::author_url ' + data[i].html_url,
+                );
+                this.setState(
+                  {
+                    code,
+                  },
+                  () => this.handleReload(),
+                );
+                break;
+              }
+            }
+          }
+        }.bind(this),
+        error: function(e) {
+          console.log('Error while fetching github url', e);
+        },
+      });
+    }
   };
 
   loadgroups() {
@@ -229,7 +278,6 @@ export default class SkillCreator extends Component {
       /^::language\s(.*)$/m,
       `::language ${value}`,
     );
-
     this.setState(
       {
         languageValue: value,


### PR DESCRIPTION
Fixes #1422 

Changes: 
1. Prefill the author name and autor_url in the skill code.
2. The author URL is the user's GitHub profile.


Surge Deployment Link: https://susi--cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/10573038/43684415-2c483b4c-98bd-11e8-8e14-eecf2da6cec8.png)
