### PR TITLE
Linked SUSI Skills to homepage on the category pages

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -1062,7 +1062,9 @@ export default class BrowseSkill extends React.Component {
                         }}
                       >
                         {this.state.skills.length} result(s) for&nbsp;<b>
-                          SUSI Skills
+                          <Link to="/">
+                            <div className="susi-skills">SUSI Skills</div>
+                          </Link>
                         </b>
                         {this.props.routeValue && (
                           <div style={{ display: 'flex' }}>

--- a/src/components/BrowseSkill/custom.css
+++ b/src/components/BrowseSkill/custom.css
@@ -22,6 +22,16 @@ div.scrolling-wrapper::-webkit-scrollbar {
     cursor: pointer;
 }
 
+.susi-skills {
+    color: rgba(0,0,0,.65);
+    width: fit-content;
+}
+
+.susi-skills:hover {
+    color: #4285f4;
+    cursor: pointer;
+}
+
 .category-sidebar-section {
     margin-top: 15px;
     margin-left: 12px;


### PR DESCRIPTION
Fixes #1375 

Changes: Linked `SUSI Skills` to homepage on the category pages.

Surge Deployment Link: https://pr-1459-fossasia-susi-skill-cms.surge.sh

