### PR TITLE
Display the chatbot widget only for legitimate users

### DIFF
--- a/public/susi-chatbot.js
+++ b/public/susi-chatbot.js
@@ -36,11 +36,11 @@ if(typeof jQuery=='undefined') {
 	var jqTag = document.createElement('script');
 	jqTag.type = 'text/javascript';
 	jqTag.src = 'https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js';
-	jqTag.onload = enableBot;
+	jqTag.onload = getTheme;
 	headTag.appendChild(jqTag);
 } else {
 	// to ensure jquery has loaded
-	enableBot();
+	getTheme();
 }
 
 // get custom theme from user
@@ -67,6 +67,12 @@ function getTheme(){
 			jsonp: 'callback',
 			crossDomain: true,
 			success: function(data) {
+				if (!data.accepted) {
+					// not allowed to use. Exit.
+					console.log(data.message);
+					return;
+				}
+				enableBot();
 				if(data.skill_metadata && data.skill_metadata.design){
 				let settings = data.skill_metadata.design;
 				botbuilderBackgroundBody = settings.bodyBackground?settings.bodyBackground:botbuilderBackgroundBody;
@@ -79,6 +85,7 @@ function getTheme(){
 				botbuilderIconImg = settings.botIconImage?settings.botIconImage:botbuilderIconImg;
 				applyTheme();
 			}
+
 			},
 			error: function(e) {
 				console.log(e);
@@ -111,10 +118,9 @@ function applyTheme(){
 }
 
 function enableBot() {
-	getTheme();
 	$(document).ready(function() {
 
-		var baseUrl = "https://api.susi.ai/susi/chat.json?q=";
+		var baseUrl = api_url + "/susi/chat.json?q=";
 		var msgNumber = 0;//stores the message number to set id
 
 		// Add dynamic html bot content(Widget style)


### PR DESCRIPTION
Fixes #1407 

Changes: 
Display the chatbot widget only if the server sends a successful response in the `getSkillMetadata.json` API. 
(The server will send `accepted: false` in the case if the chatbot is deployed in a site not allowed by the bot creator. Thus in this case, the chatbot will not be displayed at all. Even if the person changes the javascript to display the chatbot, it won't be able to get responses from the server for that private skill in the `chat.json` API, since domain address check is happening in this case also in the server side)

Surge Deployment Link: https://pr-1467-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
Added my site in the configure tab and saved the skill:
![image](https://user-images.githubusercontent.com/17807257/43839929-00a75586-9b3d-11e8-8c7e-4dab2033f314.png)

The bot is working on the domain specified:
![image](https://user-images.githubusercontent.com/17807257/43701091-9d4335a8-9972-11e8-912f-da30796bf165.png)

It will not work on any other domain