### PR TITLE
Removed Permissions tab from Admin Panel

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -221,9 +221,6 @@ class Admin extends Component {
                       <TabPane tab="Skills" key="3">
                         <ListSkills />
                       </TabPane>
-                      <TabPane tab="Permissions" key="4">
-                        Permission Content Tab
-                      </TabPane>
                     </Tabs>
                   </Paper>
                 </div>


### PR DESCRIPTION
Fixes #1469 

Changes: Removed `Permissions` tab from Admin Panel. This is to keep it aligned with the current status on the accounts repo.

Surge Deployment Link: https://pr-1470-fossasia-susi-skill-cms.surge.sh
