### PR TITLE
Fixes #1217: Implement Staff Picks on home page

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -88,6 +88,7 @@ export default class BrowseSkill extends React.Component {
       skillsLoaded: false,
       filter: '&applyFilter=true&filter_name=descending&filter_type=rating',
       searchQuery: '',
+      staffPicksSkills: [],
       topRatedSkills: [],
       topUsedSkills: [],
       topFeedbackSkills: [],
@@ -357,6 +358,7 @@ export default class BrowseSkill extends React.Component {
       success: function(data) {
         self.setState({
           skillsLoaded: true,
+          staffPicksSkills: data.metrics.staffPicks,
           topRatedSkills: data.metrics.rating,
           topUsedSkills: data.metrics.usage,
           latestUpdatedSkills: data.metrics.latest,
@@ -902,6 +904,30 @@ export default class BrowseSkill extends React.Component {
 
             {this.state.skillsLoaded ? (
               <div style={styles.container}>
+                {this.state.staffPicksSkills.length &&
+                !this.state.searchQuery.length &&
+                !this.state.ratingRefine &&
+                !this.state.timeFilter ? (
+                  <div style={metricsContainerStyle}>
+                    <div
+                      style={styles.metricsHeader}
+                      className="metrics-header"
+                    >
+                      <h4>{'Staff Picks'}</h4>
+                    </div>
+                    {/* Scroll Id must be unique for all instances of SkillCardList*/}
+                    {!this.props.routeType && (
+                      <SkillCardScrollList
+                        scrollId="staffPicks"
+                        skills={this.state.staffPicksSkills}
+                        modelValue={this.state.modelValue}
+                        languageValue={this.state.languageValue}
+                        skillUrl={this.state.skillUrl}
+                      />
+                    )}
+                  </div>
+                ) : null}
+
                 {this.state.topRatedSkills.length &&
                 !this.state.searchQuery.length &&
                 !this.state.ratingRefine &&


### PR DESCRIPTION
Fixes #1217 

Changes: 
*  Implement Staff Picks on home page

Surge Deployment Link: https://pr-1487-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![deepinscreenshot_select-area_20180808104212](https://user-images.githubusercontent.com/12656846/43817559-bee7f172-9af7-11e8-89dc-8797b12991a8.png)

