### PR TITLE
Allow resizing of height of skill editor

### DIFF
--- a/src/components/SkillCreator/SkillViews/CodeView.js
+++ b/src/components/SkillCreator/SkillViews/CodeView.js
@@ -196,8 +196,9 @@ export default class CodeView extends React.Component {
               editorProps={{ $blockScrolling: true }}
               style={{
                 resize: 'vertical',
-                overflowY: 'auto',
+                overflowY: 'scroll',
                 minHeight: '200px',
+                maxHeight: '560px',
               }}
             />
           </div>


### PR DESCRIPTION
Fixes #1430 

Changes: Minor change in CSS to allow resizing of height of skill editor.

Surge Deployment Link: https://pr-1491-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

![aug-08-2018 21-49-03](https://user-images.githubusercontent.com/31174685/43850263-18ed4732-9b55-11e8-85a5-b15f7f3c7a20.gif)

