### PR TITLE
Fixes #1506: Display loader while visiting the admin page

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -28,6 +28,7 @@ class Admin extends Component {
       loadingUsers: true,
       loadingSkills: true,
       isAdmin: false,
+      loading: true,
     };
   }
 


### PR DESCRIPTION
Fixes #1506 

Changes: Added the missing state which is responsible for displaying the loader

Surge Deployment Link: https://pr-1507-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
goto /admin