### PR TITLE
Fixes #1497: Add checkbox to refine staff picks skills

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -79,6 +79,7 @@ export default class BrowseSkill extends React.Component {
       languageValue: cookies.get('languages') || ['en'],
       showSkills: '',
       showReviewedSkills: false,
+      showStaffPicks: false,
       expertValue: null,
       skills: [],
       groups: [],
@@ -149,19 +150,28 @@ export default class BrowseSkill extends React.Component {
     });
   };
 
-  handleShowSkills = () => {
-    $('.select')
-      .find('svg')
-      .css({ fill: '#4285f4' });
-    let value = !this.state.showReviewedSkills;
-    let showSkills = value ? '&reviewed=true' : '';
+  handleShowSkills = ({ reviewed, staffPicks }) => {
+    let showSkills;
+    if (reviewed !== undefined) {
+      showSkills = `&reviewed=${reviewed}`;
+      this.setState({ showReviewedSkills: reviewed });
+    } else {
+      showSkills = `&reviewed=${this.state.showReviewedSkills}`;
+    }
+
+    if (staffPicks !== undefined) {
+      showSkills += `&staffPicks=${staffPicks}`;
+      this.setState({ showStaffPicks: staffPicks });
+    } else {
+      showSkills += `&staffPicks=${this.state.showStaffPicks}`;
+    }
+
     this.setState(
       {
-        showReviewedSkills: value,
-        showSkills: showSkills,
+        showSkills,
         skillsLoaded: false,
       },
-      function() {
+      () => {
         this.loadCards();
       },
     );
@@ -585,6 +595,22 @@ export default class BrowseSkill extends React.Component {
                   }}
                 >
                   <Checkbox
+                    label="Staff Picks"
+                    labelPosition="right"
+                    className="select"
+                    checked={this.state.showStaffPicks}
+                    labelStyle={{ fontSize: '14px' }}
+                    iconStyle={{ left: '4px' }}
+                    style={{
+                      width: '256px',
+                      paddingLeft: '8px',
+                      top: '3px',
+                    }}
+                    onCheck={(event, isInputChecked) => {
+                      this.handleShowSkills({ staffPicks: isInputChecked });
+                    }}
+                  />
+                  <Checkbox
                     label="Show Only Reviewed Skills"
                     labelPosition="right"
                     className="select"
@@ -596,7 +622,9 @@ export default class BrowseSkill extends React.Component {
                       paddingLeft: '8px',
                       top: '3px',
                     }}
-                    onCheck={this.handleShowSkills}
+                    onCheck={(event, isInputChecked) => {
+                      this.handleShowSkills({ reviewed: isInputChecked });
+                    }}
                   />
                 </div>
               )}


### PR DESCRIPTION
Fixes #1497 

Changes: 
* Add checkbox to refine staff picks skills
* Also optimized the logic to change API call params

Surge Deployment Link: https://pr-1510-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

![screenshot from 2018-08-10 10-33-04](https://user-images.githubusercontent.com/12656846/43939837-1ae4c8c2-9c8a-11e8-9164-4be026574b90.png)
