### PR TITLE
Decrease space and UI improvements in design section of botbuilder

### DIFF
--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -66,12 +66,17 @@
 	border-radius: 3px;
 	border: solid 1px #0000006e;
 	cursor: pointer;
+	margin-right: 10px;
+	margin-bottom: -8px;
 }
 .color-picker-wrap>div{
 	display: inline-block;
 }
-.color-picker-wrap>div>div{
-	width:200px;
+.color-picker-wrap>div>div {
+    width: 90px !important; /* csslint allow: known-properties, important */
+}
+.color-picker-wrap>div>div>input {
+    text-align: center;
 }
 .bot-avatar{
 	width: 60px;

--- a/src/components/BotBuilder/BotBuilderPages/DesignViews/UIView.js
+++ b/src/components/BotBuilder/BotBuilderPages/DesignViews/UIView.js
@@ -528,148 +528,143 @@ class UIView extends Component {
     const customizeComponents = customiseOptionsList.map(component => {
       return (
         <div key={component.id} className="circleChoose">
-          <Grid>
-            <Row>
-              <Col xs={12} md={6} lg={6}>
-                {component.id === 7 ? (
-                  <div style={{ display: 'flex', flexDirection: 'column' }}>
-                    <div
-                      style={{
-                        fontSize: '18px',
-                        paddingTop: '12px',
-                        fontWeight: '400',
-                      }}
-                    >
-                      {component.name}
-                    </div>
-                    <div
-                      style={{
-                        fontSize: '15px',
-                        paddingTop: '12px',
-                        fontWeight: '300',
-                      }}
-                    >
-                      {component.helperText}
-                    </div>
+          <Row style={{ marginBottom: '15px' }}>
+            <Col xs={12} md={6} lg={6}>
+              {component.id === 7 ? (
+                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                  <div
+                    style={{
+                      fontSize: '18px',
+                      fontWeight: '400',
+                    }}
+                  >
+                    {component.name}
                   </div>
-                ) : (
-                  <div style={{ display: 'flex', flexDirection: 'column' }}>
-                    <div
-                      style={{
-                        fontSize: '18px',
-                        paddingTop: '12px',
-                        fontWeight: '400',
-                      }}
-                    >
-                      Color of {component.name}
+                  <div
+                    style={{
+                      fontSize: '15px',
+                      fontWeight: '300',
+                    }}
+                  >
+                    {component.helperText}
+                  </div>
+                </div>
+              ) : (
+                <div style={{ display: 'flex', flexDirection: 'column' }}>
+                  <div
+                    style={{
+                      fontSize: '18px',
+                      paddingTop: '12px',
+                      fontWeight: '400',
+                    }}
+                  >
+                    Color of {component.name}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: '15px',
+                      fontWeight: '300',
+                    }}
+                  >
+                    {component.helperText}
+                  </div>
+                  {component.id === 1 && (
+                    <div style={{ textAlign: 'right' }}>
+                      <Toggle
+                        label="Choose background image"
+                        labelStyle={{
+                          width: 'auto',
+                          fontSize: '14px',
+                          fontWeight: '300',
+                        }}
+                        defaultToggled={this.state.showBackgroundImageChange}
+                        onToggle={this.handleShowBackgroundImageChangeToggle}
+                        style={{ textAlign: 'right', marginTop: '10px' }}
+                        thumbSwitchedStyle={{
+                          backgroundColor: 'rgb(66, 133, 245)',
+                        }}
+                        trackSwitchedStyle={{
+                          backgroundColor: 'rgba(151, 184, 238, 0.85)',
+                        }}
+                      />
                     </div>
-                    <div
+                  )}
+                </div>
+              )}
+            </Col>
+            <Col xs={12} md={6} lg={6}>
+              {component.id !== 7 &&
+              !(
+                component.id === 1 &&
+                this.state.showBackgroundImageChange === true
+              ) ? (
+                <div style={{ display: 'flex', flexDirection: 'row' }}>
+                  <div className="color-picker-wrap">
+                    <span
+                      className="color-box"
+                      onClick={() => this.handleClickColorBox(component.id)}
                       style={{
-                        fontSize: '15px',
-                        paddingTop: '12px',
-                        fontWeight: '300',
+                        backgroundColor: this.state[component.component],
                       }}
-                    >
-                      {component.helperText}
-                    </div>
-                    {component.id === 1 && (
-                      <div style={{ textAlign: 'right' }}>
-                        <Toggle
-                          label="Choose background image"
-                          labelStyle={{
-                            width: 'auto',
-                            fontSize: '14px',
-                            fontWeight: '300',
-                          }}
-                          defaultToggled={this.state.showBackgroundImageChange}
-                          onToggle={this.handleShowBackgroundImageChangeToggle}
-                          style={{ textAlign: 'right', marginTop: '10px' }}
-                          thumbSwitchedStyle={{
-                            backgroundColor: 'rgb(66, 133, 245)',
-                          }}
-                          trackSwitchedStyle={{
-                            backgroundColor: 'rgba(151, 184, 238, 0.85)',
-                          }}
+                    />
+                    <ColorPicker
+                      className="color-picker"
+                      style={{ display: 'inline-block', width: '60px' }}
+                      name="color"
+                      id={'colorPicker' + component.id}
+                      defaultValue={this.state[component.component]}
+                      onChange={color =>
+                        this.handleChangeColor(component.component, color)
+                      }
+                    />
+                  </div>
+                </div>
+              ) : null}
+              {component.component === 'botbuilderBackgroundBody' &&
+                this.state.showBackgroundImageChange === true && (
+                  <div>
+                    <br />
+                    <form style={{ display: 'inline-block' }}>
+                      <label
+                        className="file-upload-btn"
+                        title="Upload Background Image"
+                      >
+                        <input
+                          disabled={this.state.uploadingBodyBackgroundImg}
+                          type="file"
+                          onChange={this.handleChangeBodyBackgroundImage}
+                          accept="image/x-png,image/gif,image/jpeg"
                         />
+                        {this.state.uploadingBodyBackgroundImg ? (
+                          <CircularProgress color="#ffffff" size={32} />
+                        ) : (
+                          'Upload Image'
+                        )}
+                      </label>
+                    </form>
+                    {this.state.botbuilderBodyBackgroundImg && (
+                      <div
+                        style={{
+                          display: 'flex',
+                          flexDirection: 'row',
+                          marginTop: '10px',
+                        }}
+                      >
+                        <h3>{this.state.botbuilderBodyBackgroundImgName}</h3>
+                        <span title="Remove image">
+                          <Close
+                            className="remove-icon"
+                            onTouchTap={this.handleRemoveUrlBody}
+                          />
+                        </span>
                       </div>
                     )}
                   </div>
                 )}
-              </Col>
-              <Col xs={12} md={6} lg={6}>
-                {component.id !== 7 &&
-                !(
-                  component.id === 1 &&
-                  this.state.showBackgroundImageChange === true
-                ) ? (
-                  <div style={{ display: 'flex', flexDirection: 'row' }}>
-                    <div className="color-picker-wrap">
-                      <ColorPicker
-                        className="color-picker"
-                        style={{ display: 'inline-block', float: 'left' }}
-                        name="color"
-                        id={'colorPicker' + component.id}
-                        defaultValue={this.state[component.component]}
-                        onChange={color =>
-                          this.handleChangeColor(component.component, color)
-                        }
-                      />
-                      <span
-                        className="color-box"
-                        onClick={() => this.handleClickColorBox(component.id)}
-                        style={{
-                          backgroundColor: this.state[component.component],
-                        }}
-                      />
-                    </div>
-                  </div>
-                ) : null}
-                {component.component === 'botbuilderBackgroundBody' &&
-                  this.state.showBackgroundImageChange === true && (
-                    <div>
-                      <br />
-                      <form style={{ display: 'inline-block' }}>
-                        <label
-                          className="file-upload-btn"
-                          title="Upload Background Image"
-                        >
-                          <input
-                            disabled={this.state.uploadingBodyBackgroundImg}
-                            type="file"
-                            onChange={this.handleChangeBodyBackgroundImage}
-                            accept="image/x-png,image/gif,image/jpeg"
-                          />
-                          {this.state.uploadingBodyBackgroundImg ? (
-                            <CircularProgress color="#ffffff" size={32} />
-                          ) : (
-                            'Upload Image'
-                          )}
-                        </label>
-                      </form>
-                      {this.state.botbuilderBodyBackgroundImg && (
-                        <div
-                          style={{
-                            display: 'flex',
-                            flexDirection: 'row',
-                            marginTop: '10px',
-                          }}
-                        >
-                          <h3>{this.state.botbuilderBodyBackgroundImgName}</h3>
-                          <span title="Remove image">
-                            <Close
-                              className="remove-icon"
-                              onTouchTap={this.handleRemoveUrlBody}
-                            />
-                          </span>
-                        </div>
-                      )}
-                    </div>
-                  )}
-              </Col>
-            </Row>
-          </Grid>
+            </Col>
+          </Row>
           {component.component === 'botbuilderAvatar' && (
-            <div style={{ padding: '25px  0 25px 0' }}>
+            <div style={{ padding: '10px  0 25px 0' }}>
               {this.state.avatars.map(icon => {
                 return (
                   <span
@@ -726,7 +721,6 @@ class UIView extends Component {
               </form>
             </div>
           )}
-          <br />
         </div>
       );
     });
@@ -739,7 +733,7 @@ class UIView extends Component {
           </div>
         ) : (
           <div className="design-box">
-            {this.state.loadedSettings && customizeComponents}
+            {this.state.loadedSettings && <Grid>{customizeComponents}</Grid>}
             <RaisedButton
               label={
                 this.state.resetting ? (


### PR DESCRIPTION
Fixes #1438 

Changes: 
- decrease space between headings 
- put color box before the color code input field
- decrease width of color code input field

I have to put `!important` in one line of `Botbuilder.css` file. This is required to overwrite the default width of the color code input field.

Surge Deployment Link: https://pr-1512-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/17807257/43939731-8e94c53e-9c89-11e8-9934-628f3f93a2e1.png)

