### PR TITLE
Upgrade npm and fix some npm warings

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "enzyme": "2.9.1",
-    "eslint": "4.19.1",
+    "eslint": "3.19.0",
     "eslint-config-prettier": "2.9.0",
     "eslint-plugin-babel": "4.1.2",
     "eslint-plugin-jsx": "0.0.2",
@@ -62,7 +62,6 @@
     "eslint-plugin-react": "7.10.0",
     "husky": "0.14.3",
     "lint-staged": "7.2.0",
-    "match-media": "0.2.0",
     "prettier": "1.13.5",
     "react-scripts": "1.0.7",
     "react-test-renderer": "15.6.2"


### PR DESCRIPTION
Fixes #1526 

Changes: 
- Upgraded npm using `npm i npm@latest` as suggested in the warings
- Added missing dependencies required by other pre installed dependencies

Surge Deployment Link: https://pr-1527-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![w2](https://user-images.githubusercontent.com/30981465/43991436-7386f7f6-9d8a-11e8-8370-cdb1d51e06c2.png)
![w5](https://user-images.githubusercontent.com/30981465/43991439-7ffb2f98-9d8a-11e8-9953-a4bc39f9a065.png)
