### PR TITLE
Consistent styling in all dialog boxes in Admin Panel

### DIFF
--- a/src/components/Admin/ListSkills/ListSkills.css
+++ b/src/components/Admin/ListSkills/ListSkills.css
@@ -9,3 +9,6 @@
     margin-left: 30px;
     margin-right: 30px;
 }
+.skillName{
+	font-weight: bold;
+}

--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -711,7 +711,8 @@ export default class ListSkills extends React.Component {
                               open={this.state.showDeleteDialog}
                             >
                               <div>
-                                Are you sure you want to delete {skillName}?
+                                Are you sure you want to delete{' '}
+                                <span className="skillName">{skillName}</span>?
                               </div>
                             </Dialog>
                             <Dialog
@@ -721,7 +722,8 @@ export default class ListSkills extends React.Component {
                               open={this.state.showRestoreDialog}
                             >
                               <div>
-                                Are you sure you want to restore {skillName}?
+                                Are you sure you want to restore{' '}
+                                <span className="skillName">{skillName}</span>?
                               </div>
                             </Dialog>
                             <Dialog
@@ -731,15 +733,8 @@ export default class ListSkills extends React.Component {
                               open={this.state.restoreSuccessDialog}
                             >
                               <div>
-                                You successfully restored
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
-                                  {skillName}
-                                </span>
+                                You successfully restored{' '}
+                                <span className="skillName">{skillName}</span>
                                 !
                               </div>
                             </Dialog>
@@ -750,15 +745,8 @@ export default class ListSkills extends React.Component {
                               open={this.state.restoreFailureDialog}
                             >
                               <div>
-                                Error!
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
-                                  {skillName}
-                                </span>
+                                Error!{' '}
+                                <span className="skillName">{skillName}</span>{' '}
                                 could not be restored!
                               </div>
                             </Dialog>
@@ -769,15 +757,8 @@ export default class ListSkills extends React.Component {
                               open={this.state.deleteSuccessDialog}
                             >
                               <div>
-                                You successfully deleted
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
-                                  {skillName}
-                                </span>
+                                You successfully deleted{' '}
+                                <span className="skillName">{skillName}</span>
                                 !
                               </div>
                             </Dialog>
@@ -788,15 +769,8 @@ export default class ListSkills extends React.Component {
                               open={this.state.deleteFailureDialog}
                             >
                               <div>
-                                Error!
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
-                                  {skillName}
-                                </span>
+                                Error!{' '}
+                                <span className="skillName">{skillName}</span>{' '}
                                 could not be deleted!
                               </div>
                             </Dialog>
@@ -808,15 +782,8 @@ export default class ListSkills extends React.Component {
                               open={this.state.changeStatusSuccessDialog}
                             >
                               <div>
-                                Status of
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
-                                  {skillName}
-                                </span>
+                                Status of{' '}
+                                <span className="skillName">{skillName}</span>{' '}
                                 has been changed successfully!
                               </div>
                             </Dialog>
@@ -827,15 +794,8 @@ export default class ListSkills extends React.Component {
                               open={this.state.changeStatusFailureDialog}
                             >
                               <div>
-                                Error! Status of
-                                <span
-                                  style={{
-                                    fontWeight: 'bold',
-                                    margin: '0 5px',
-                                  }}
-                                >
-                                  {skillName}
-                                </span>
+                                Error! Status of{' '}
+                                <span className="skillName">{skillName}</span>{' '}
                                 could not be changed!
                               </div>
                             </Dialog>


### PR DESCRIPTION
Fixes #1530 

Changes: Consistent styling in all dialog boxes in Admin Panel

Surge Deployment Link: https://pr-1531-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
<img width="770" alt="screen shot 2018-08-12 at 8 36 05 am" src="https://user-images.githubusercontent.com/31135861/43998217-00dcf32a-9e0e-11e8-8f3b-fe3a0f2f81f4.png">

After:
<img width="771" alt="screen shot 2018-08-12 at 8 58 38 am" src="https://user-images.githubusercontent.com/31135861/43998218-06a1a828-9e0e-11e8-86e8-5ffac52c6bca.png">
