### PR TITLE
Fixes #1524: Display rating refine count at the top of skill list component

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -1074,12 +1074,11 @@ export default class BrowseSkill extends React.Component {
                   </div>
                 ) : null}
 
-                {(this.state.skills.length && this.props.routeType) ||
-                (this.state.searchQuery.length && this.state.skills.length) ||
-                this.state.ratingRefine ||
-                (this.state.timeFilter && this.state.skills.length) ? (
+                {metricsHidden ? (
                   <div>
-                    {this.state.searchQuery.length || this.props.routeType ? (
+                    {this.state.searchQuery.length ||
+                    this.props.routeType ||
+                    this.state.ratingRefine ? (
                       <div
                         style={{
                           display: 'flex',
@@ -1107,6 +1106,15 @@ export default class BrowseSkill extends React.Component {
                               style={{ color: '#4286f4', fontWeight: 'bold' }}
                             >
                               &quot;{this.state.searchQuery}&quot;
+                            </div>
+                          </div>
+                        )}
+                        {this.state.ratingRefine > 0 && (
+                          <div style={{ display: 'flex' }}>
+                            :&nbsp;<div
+                              style={{ color: '#4286f4', fontWeight: 'bold' }}
+                            >
+                              {this.state.ratingRefine} Stars & Up
                             </div>
                           </div>
                         )}


### PR DESCRIPTION
Fixes #1524 

Changes: Display refine count at the top of skill listing.

Surge Deployment Link: https://pr-1537-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21009455/44014000-d51f483a-9ee6-11e8-9518-d963a195ec8d.png)
