### PR TITLE
Displayed number of System Skills in the Skill Types card in Admin Panel

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -399,6 +399,18 @@ class Admin extends Component {
                             }}
                           >
                             <p>
+                              System Skills:{' '}
+                              {this.state.skillStats.systemSkills
+                                ? this.state.skillStats.systemSkills
+                                : 0}
+                            </p>
+                            <p>
+                              Staff Picks:{' '}
+                              {this.state.skillStats.staffPicks
+                                ? this.state.skillStats.staffPicks
+                                : 0}
+                            </p>
+                            <p>
                               Editable:{' '}
                               {this.state.skillStats.editableSkills
                                 ? this.state.skillStats.editableSkills
@@ -408,12 +420,6 @@ class Admin extends Component {
                               Non Editable:{' '}
                               {this.state.skillStats.nonEditableSkills
                                 ? this.state.skillStats.nonEditableSkills
-                                : 0}
-                            </p>
-                            <p>
-                              Staff Picks :{' '}
-                              {this.state.skillStats.staffPicks
-                                ? this.state.skillStats.staffPicks
                                 : 0}
                             </p>
                           </Card>


### PR DESCRIPTION
Fixes #1558 

Changes: Displayed number of `System Skills` in the `Skill Types` card in Admin Panel

Surge Deployment Link: https://pr-1559-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
<img width="303" alt="screen shot 2018-08-16 at 7 32 59 am" src="https://user-images.githubusercontent.com/31135861/44182944-a4c4f300-a126-11e8-90bc-a411f1eecc6c.png">

