### PR TITLE
Apply include/exclude default skills setting in preview

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -774,6 +774,7 @@ class BotWizard extends React.Component {
                     <Preview
                       designData={this.state.designData}
                       skill={this.state.buildCode}
+                      configCode={this.state.configCode}
                       botBuilder={true}
                     />
                   </div>

--- a/src/components/BotBuilder/Preview/Preview.js
+++ b/src/components/BotBuilder/Preview/Preview.js
@@ -158,6 +158,12 @@ class Preview extends Component {
   send = text => {
     let url = urls.API_URL + '/susi/chat.json?q=' + encodeURIComponent(text);
     url += '&instant=' + encodeURIComponent(this.props.skill);
+    const enableDefaultSkillsMatch = this.props.configCode.match(
+      /^::enable_default_skills\s(.*)$/m,
+    );
+    if (enableDefaultSkillsMatch && enableDefaultSkillsMatch[1] === 'no') {
+      url += '&excludeDefaultSkills=1';
+    }
     var thisMsgNumber = this.msgNumber;
     this.msgNumber++;
     this.setLoadingMessage(thisMsgNumber);
@@ -353,6 +359,7 @@ class Preview extends Component {
 Preview.propTypes = {
   designData: PropTypes.object,
   skill: PropTypes.string,
+  configCode: PropTypes.string,
   botBuilder: PropTypes.bool,
 };
 export default Preview;


### PR DESCRIPTION
Fixes #1550 

Changes: 
- If the user has selected not to include SUSI default skills in the configure tab, then in the preview section, `excludeDefaultSkills=1` is being sent to server. This will exclude the SUSI default skills. Otherwise it is included.

PR on the server: https://github.com/fossasia/susi_server/pull/1146

Surge Deployment Link: https://pr-1571-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
With not including default skills:
![image](https://user-images.githubusercontent.com/17807257/44281798-a00f5480-a276-11e8-8ba5-082584834156.png)

With including default skills:
![image](https://user-images.githubusercontent.com/17807257/44281819-aac9e980-a276-11e8-9f41-a4a2eb135937.png)

