### PR TITLE
Fix bug in signup form validation

### DIFF
--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -77,6 +77,9 @@ export default class SignUp extends Component {
       passwordValue = event.target.value;
       validPassword = passwordValue.length >= 6;
       passwordError = !(passwordValue && validPassword);
+      passwordConfirmError = !(
+        passwordValue === this.state.confirmPasswordValue
+      );
     } else if (event.target.name === 'confirmPassword') {
       confirmPasswordValue = event.target.value;
       validPassword = confirmPasswordValue === passwordValue;


### PR DESCRIPTION
Fixes #831 

Changes: Fixed the bug - whenever a user enters same password on new password and verify password section and then changes the new password, the form validation is still set true.

Surge Deployment Link: https://pr-1575-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
Bug:
![b2](https://user-images.githubusercontent.com/30981465/44302740-b982d000-a34c-11e8-9a30-23f73ed39512.png)
Fix:
![b1](https://user-images.githubusercontent.com/30981465/44302741-be478400-a34c-11e8-9620-aec4c3300f37.png)
