### PR TITLE
Fixes #1567: Integrate /getAvatar.png to display avatar

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -20,7 +20,7 @@ import CircleImage from '../CircleImage/CircleImage';
 import MenuItem from 'material-ui/MenuItem';
 import { Link } from 'react-router-dom';
 import susiWhite from '../images/SUSIAI-white.png';
-import { urls, colors, isProduction, getAvatarProps } from '../../utils';
+import { urls, colors, isProduction } from '../../utils';
 import $ from 'jquery';
 import './StaticAppBar.css';
 // import ListUser from '../Admin/ListUser/ListUser';
@@ -197,7 +197,12 @@ class StaticAppBar extends Component {
     const isLoggedIn = !!cookies.get('loggedIn');
     let avatarProps = null;
     if (isLoggedIn) {
-      avatarProps = getAvatarProps(cookies.get('emailId'));
+      avatarProps = {
+        name: cookies.get('emailId'),
+        src: `${urls.API_URL}/getAvatar.png?access_token=${cookies.get(
+          'loggedIn',
+        )}`,
+      };
     }
 
     let TopRightMenu = props => (


### PR DESCRIPTION
Fixes #1567 

Changes: [Add here what changes were made in this issue and if possible provide links.]
* Integrate /getAvatar.png servlet to display avatar image

Surge Deployment Link: https://pr-1577-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![deepinscreenshot_select-area_20180821233511](https://user-images.githubusercontent.com/12656846/44420174-e1677300-a59a-11e8-987c-02c7e9e9cd83.png)

