### PR TITLE
Fixes #1260: Fix Language Dropdown Position

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -432,7 +432,7 @@ export default class BrowseSkill extends React.Component {
     let backToHome = null;
 
     let metricsContainerStyle = {
-      width: '1090px',
+      width: '100%',
       margin: window.innerWidth >= 430 ? '10px' : '10px 0px 10px 0px',
     };
 


### PR DESCRIPTION
Fixes #1260 

Changes: The width of metricsContainer was set to '1090px' which caused the top bar to go offscreen on smaller screen size below 1300px wide. I have set it to 100% width now, which seems to resolve the problem.

Surge Deployment Link: https://pr-1582-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
