### PR TITLE
Fixes #1584: Get latest avatar image rather than cached copy

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -196,12 +196,14 @@ class StaticAppBar extends Component {
 
     const isLoggedIn = !!cookies.get('loggedIn');
     let avatarProps = null;
+    const date = new Date();
+    const timestamp = date.getTime();
     if (isLoggedIn) {
       avatarProps = {
         name: cookies.get('emailId'),
         src: `${urls.API_URL}/getAvatar.png?access_token=${cookies.get(
           'loggedIn',
-        )}`,
+        )}&q=${timestamp}`,
       };
     }
 


### PR DESCRIPTION
Fixes #1584

Changes: 
* Get latest avatar image rather than cached copy

Surge Deployment Link: https://pr-1585-fossasia-susi-skill-cms.surge.sh
