### PR TITLE
Removed timestamp arguement from avatarURL

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -53,6 +53,7 @@ class StaticAppBar extends Component {
       showOptions: false,
       showAdmin: false,
       anchorEl: null,
+      timestamp: new Date().getTime(),
     };
   }
 
@@ -67,7 +68,6 @@ class StaticAppBar extends Component {
   componentDidMount() {
     window.addEventListener('scroll', this.handleScroll);
     let url;
-
     if (cookies.get('loggedIn')) {
       url =
         urls.API_URL +
@@ -196,14 +196,12 @@ class StaticAppBar extends Component {
 
     const isLoggedIn = !!cookies.get('loggedIn');
     let avatarProps = null;
-    const date = new Date();
-    const timestamp = date.getTime();
     if (isLoggedIn) {
       avatarProps = {
         name: cookies.get('emailId'),
         src: `${urls.API_URL}/getAvatar.png?access_token=${cookies.get(
           'loggedIn',
-        )}&q=${timestamp}`,
+        )}&q=${this.state.timestamp}`,
       };
     }
 


### PR DESCRIPTION
Fixes #1587 

Changes: Removed timestamp URL from avatar fetch as it was triggering auto-fetch avatar everytime some event occurs.

Surge Deployment Link: https://pr-1588-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

![susiski](https://user-images.githubusercontent.com/21199234/45452093-a7514300-b6fa-11e8-8dbc-3e5be17336d9.gif)

