### PR TITLE
SUSI logo in footer is now centered when screen size is decreased

### DIFF
--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -90,6 +90,6 @@
     }
 
     .susi-logo{
-        text-align: center;
+        margin: 10px auto;
     }
 }


### PR DESCRIPTION
Fixes #1592 

Changes: The SUSI logo in the footer is now in the center when the screen size is decreased.

Surge Deployment Link: https://pr-1593-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot from 2018-09-18 16-52-39](https://user-images.githubusercontent.com/27884543/45684462-0f24e500-bb64-11e8-9f40-598a9b3fbc5d.png)
