### PR TITLE
Implemented Pagination

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -20,6 +20,10 @@ import Person from 'material-ui/svg-icons/social/person';
 import ActionViewModule from 'material-ui/svg-icons/action/view-module';
 import ActionViewStream from 'material-ui/svg-icons/action/view-stream';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
+import FloatingActionButton from 'material-ui/FloatingActionButton';
+import NavigationArrowBack from 'material-ui/svg-icons/navigation/arrow-back';
+import NavigationArrowForward from 'material-ui/svg-icons/navigation/arrow-forward';
+
 // eslint-disable-next-line
 import CircleImage from '../CircleImage/CircleImage';
 import CircularProgress from 'material-ui/CircularProgress';
@@ -82,6 +86,7 @@ export default class BrowseSkill extends React.Component {
       showStaffPicks: false,
       expertValue: null,
       skills: [],
+      listSkills: [],
       groups: [],
       languages: [],
       groupSelect: false,
@@ -99,6 +104,9 @@ export default class BrowseSkill extends React.Component {
       ratingRefine: null,
       timeFilter: null,
       viewType: 'list',
+      listOffset: 0,
+      listPage: 1,
+      entriesPerPage: 10,
     };
   }
 
@@ -147,6 +155,61 @@ export default class BrowseSkill extends React.Component {
       } else {
         this.loadMetricsSkills();
       }
+    });
+  };
+
+  handleEntriesPerPageChange = (event, index, values) => {
+    let { skills, listPage } = this.state;
+    let entriesPerPage = values;
+    let listOffset = entriesPerPage * (listPage - 1);
+    if (listOffset > skills.length - 1) {
+      listPage = Math.ceil(skills.length / entriesPerPage);
+      listOffset = entriesPerPage * (listPage - 1);
+    }
+    // console.log(listPage, listOffset);
+    this.setState({
+      entriesPerPage,
+      listOffset,
+      listPage,
+      listSkills: skills.slice(listOffset, listOffset + values),
+    });
+  };
+
+  handlePageChange = (event, index, value) => {
+    if (value !== undefined) {
+      let entriesPerPage = this.state.entriesPerPage;
+      let listPage = value;
+      let listOffset = entriesPerPage * (listPage - 1);
+      // console.log(listOffset);
+      let skills = this.state.skills;
+      this.setState({
+        listPage,
+        listOffset,
+        listSkills: skills.slice(listOffset, listOffset + entriesPerPage),
+      });
+    }
+  };
+
+  handleNavigationForward = () => {
+    let listPage = this.state.listPage + 1;
+    let listOffset = this.state.listOffset + this.state.entriesPerPage;
+    this.setState({
+      listPage,
+      listOffset,
+      listSkills: this.state.skills.slice(
+        listOffset,
+        listOffset + this.state.entriesPerPage,
+      ),
+    });
+  };
+
+  handleNavigationBackward = () => {
+    let listPage = this.state.listPage - 1;
+    let listOffset = this.state.listOffset - this.state.entriesPerPage;
+    this.setState({
+      listPage,
+      listOffset,
+      listSkills: this.state.skills.slice(listOffset, this.state.listOffset),
     });
   };
 
@@ -336,9 +399,13 @@ export default class BrowseSkill extends React.Component {
         self.setState(
           {
             skills: data.filteredData,
+            listSkills: data.filteredData.slice(0, self.state.entriesPerPage),
             // cards: cards,
             skillURL: url,
             skillsLoaded: true,
+            listOffset: 0,
+            listPage: 1,
+            entriesPerPage: 10,
           },
           function() {
             this.loadLanguages();
@@ -420,6 +487,25 @@ export default class BrowseSkill extends React.Component {
             ? ISO6391.getNativeName(name)
             : 'Universal'
         }
+      />
+    ));
+  }
+
+  pageMenuItems(values) {
+    let a = [];
+    for (
+      let i = 1;
+      i <= Math.ceil(this.state.skills.length / this.state.entriesPerPage);
+      i += 1
+    ) {
+      a.push(i);
+    }
+    return a.map(idx => (
+      <MenuItem
+        key={idx}
+        value={idx}
+        primaryText={idx.toString()}
+        label={idx.toString()}
       />
     ));
   }
@@ -1086,45 +1172,97 @@ export default class BrowseSkill extends React.Component {
                     {this.state.searchQuery.length ||
                     this.props.routeType ||
                     this.state.ratingRefine ? (
-                      <div
-                        style={{
-                          display: 'flex',
-                          margin: '0 0 10px 10px',
-                          fontSize: '16px',
-                        }}
-                      >
-                        {this.state.skills.length} result(s) for&nbsp;<b>
-                          <Link to="/">
-                            <div className="susi-skills">SUSI Skills</div>
-                          </Link>
-                        </b>
-                        {this.props.routeValue && (
-                          <div style={{ display: 'flex' }}>
-                            :&nbsp;<div
-                              style={{ color: '#4286f4', fontWeight: 'bold' }}
-                            >
-                              {this.props.routeValue}
+                      <div id={'page-filter'}>
+                        <div
+                          style={{
+                            display: 'flex',
+                          }}
+                        >
+                          {this.state.listOffset + 1}-{this.state.listOffset +
+                            this.state.entriesPerPage >
+                          this.state.skills.length
+                            ? this.state.skills.length
+                            : this.state.listOffset +
+                              this.state.entriesPerPage}{' '}
+                          out of {this.state.skills.length} result(s) for&nbsp;<b
+                          >
+                            <Link to="/">
+                              <div className="susi-skills">SUSI Skills</div>
+                            </Link>
+                          </b>
+                          {this.props.routeValue && (
+                            <div style={{ display: 'flex' }}>
+                              :&nbsp;<div
+                                style={{ color: '#4286f4', fontWeight: 'bold' }}
+                              >
+                                {this.props.routeValue}
+                              </div>
                             </div>
-                          </div>
-                        )}
-                        {this.state.searchQuery.length > 0 && (
-                          <div style={{ display: 'flex' }}>
-                            :&nbsp;<div
-                              style={{ color: '#4286f4', fontWeight: 'bold' }}
-                            >
-                              &quot;{this.state.searchQuery}&quot;
+                          )}
+                          {this.state.searchQuery.length > 0 && (
+                            <div style={{ display: 'flex' }}>
+                              :&nbsp;<div
+                                style={{ color: '#4286f4', fontWeight: 'bold' }}
+                              >
+                                &quot;{this.state.searchQuery}&quot;
+                              </div>
                             </div>
-                          </div>
-                        )}
-                        {this.state.ratingRefine > 0 && (
-                          <div style={{ display: 'flex' }}>
-                            :&nbsp;<div
-                              style={{ color: '#4286f4', fontWeight: 'bold' }}
-                            >
-                              {this.state.ratingRefine} Stars & Up
+                          )}
+                          {this.state.ratingRefine > 0 && (
+                            <div style={{ display: 'flex' }}>
+                              :&nbsp;<div
+                                style={{ color: '#4286f4', fontWeight: 'bold' }}
+                              >
+                                {this.state.ratingRefine} Stars & Up
+                              </div>
                             </div>
-                          </div>
-                        )}
+                          )}
+                        </div>
+                        <div id={'pagination'}>
+                          <SelectField
+                            floatingLabelText="Skills per page"
+                            floatingLabelFixed={false}
+                            hintText="Entries per page"
+                            style={{ width: '150px' }}
+                            value={this.state.entriesPerPage}
+                            onChange={this.handleEntriesPerPageChange}
+                          >
+                            <MenuItem
+                              value={10}
+                              key={10}
+                              primaryText={'10'}
+                              label={'10'}
+                            />
+                            <MenuItem
+                              value={20}
+                              key={20}
+                              primaryText={'20'}
+                              label={'20'}
+                            />
+                            <MenuItem
+                              value={50}
+                              key={50}
+                              primaryText={'50'}
+                              label={'50'}
+                            />
+                            <MenuItem
+                              value={100}
+                              key={100}
+                              primaryText={'100'}
+                              label={'100'}
+                            />
+                          </SelectField>
+                          <SelectField
+                            floatingLabelText="Page"
+                            floatingLabelFixed={false}
+                            hintText="Page"
+                            style={{ width: '150px' }}
+                            value={this.state.listPage}
+                            onChange={this.handlePageChange}
+                          >
+                            {this.pageMenuItems()}
+                          </SelectField>
+                        </div>
                       </div>
                     ) : (
                       ''
@@ -1132,19 +1270,42 @@ export default class BrowseSkill extends React.Component {
                     <div>
                       {this.state.viewType === 'list' ? (
                         <SkillCardList
-                          skills={this.state.skills}
+                          skills={this.state.listSkills}
                           modelValue={this.state.modelValue}
                           languageValue={this.state.languageValue}
                           skillUrl={this.state.skillUrl}
                         />
                       ) : (
                         <SkillCardGrid
-                          skills={this.state.skills}
+                          skills={this.state.listSkills}
                           modelValue={this.state.modelValue}
                           languageValue={this.state.languageValue}
                           skillUrl={this.state.skillUrl}
                         />
                       )}
+                    </div>
+                    <div id={'pageNavigation'}>
+                      <FloatingActionButton
+                        disabled={this.state.listPage === 1}
+                        style={{ marginRight: '15px' }}
+                        backgroundColor={colors.header}
+                        onClick={this.handleNavigationBackward}
+                      >
+                        <NavigationArrowBack />
+                      </FloatingActionButton>
+                      <FloatingActionButton
+                        disabled={
+                          this.state.listPage ===
+                          Math.ceil(
+                            this.state.skills.length /
+                              this.state.entriesPerPage,
+                          )
+                        }
+                        backgroundColor={colors.header}
+                        onClick={this.handleNavigationForward}
+                      >
+                        <NavigationArrowForward />
+                      </FloatingActionButton>
                     </div>
                   </div>
                 ) : (

--- a/src/components/BrowseSkill/custom.css
+++ b/src/components/BrowseSkill/custom.css
@@ -58,9 +58,48 @@ div.scrolling-wrapper::-webkit-scrollbar {
     font-size: 20px;
 }
 
+#pagination {
+    position: relative;
+    right: 0;
+    bottom: 27px;
+}
+
+#page-filter {
+    display: flex;
+    margin: 0 0 10px 10px;
+    font-size: 16px;
+    justify-content: space-between;
+    height: 35px;
+}
+
+#pageNavigation {
+    display: flex;
+    justify-content: center;
+    margin: 15px 0;
+}
+
+#pagination > div {
+    margin-right: 15px;
+}
+
 @media screen and (max-width: 418px) {
     .metrics-header {
         font-size: 16px;
+    }
+    #page-filter {
+        flex-direction: column;
+        height: 100%;
+    }
+    #pagination {
+        bottom: 0;
+        display: flex;
+        justify-content: space-around;
+    }
+    #pagination > div {
+        margin: 0;
+    }
+    #pageNavigation {
+        justify-content: center;
     }
 }
 
@@ -72,3 +111,6 @@ div.scrolling-wrapper::-webkit-scrollbar {
 .category-mobile-section div:last-child a {
     border-radius: 0 0 5px 5px;
 }
+
+
+


### PR DESCRIPTION
Fixes #1128

Changes: Pagination is now working for category skills page. You can set skills per page and page number from the top of the skills list and navigate forward and backward through the buttons below the skills list. I have not used the offset and count filters of the api end point which was asked in the issue, because of some issue in api (fossasia/susi_server/issues/1152). All the data is loaded when the component mounts and then part of the data is shown as page number or skills per page changes, this is better than fetching data from the server for every page.

Surge Deployment Link: https://pr-1599-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

dropdown for selecting skills per page and page number:
![screenshot from 2018-09-22 11-42-07](https://user-images.githubusercontent.com/21025052/45914099-bf913280-be5d-11e8-9534-0d3c34acd2b9.png)

buttons for forward/backward page navigation:
![screenshot from 2018-09-22 11-42-27](https://user-images.githubusercontent.com/21025052/45914106-db94d400-be5d-11e8-8c80-a55d3ef07873.png)


