### PR TITLE
loading spinner on saving skills

### DIFF
--- a/src/components/SkillCreator/SkillCreator.js
+++ b/src/components/SkillCreator/SkillCreator.js
@@ -836,7 +836,13 @@ export default class SkillCreator extends Component {
                         onChange={this.handleCommitMessageChange}
                       />
                       <RaisedButton
-                        label="Save"
+                        label={
+                          this.state.loading ? (
+                            <CircularProgress color="#ffffff" size={32} />
+                          ) : (
+                            'Save'
+                          )
+                        }
                         backgroundColor={colors.header}
                         labelColor="#fff"
                         style={{ marginLeft: 10 }}


### PR DESCRIPTION
Fixes #1191

Changes: Added a loading spinner which appears when saving a skill similiar to when saving bots.

Surge Deployment Link: https://pr-1605-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

![screenshot from 2018-09-28 12-02-04](https://user-images.githubusercontent.com/21025052/46191796-6d955480-c316-11e8-9fd1-56b3388059cc.png)

