### PR TITLE
All the charts properly aligned when screen is narrowed

### DIFF
--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -715,7 +715,7 @@ class SkillListing extends Component {
 
     const styles = {
       home: {
-        width: '100%',
+        width: '500%',
         fontSize: '14px',
       },
       right: {

--- a/src/components/SkillUsageCard/SkillUsage.css
+++ b/src/components/SkillUsageCard/SkillUsage.css
@@ -41,5 +41,10 @@
   display: flex;
   justify-content: center;
   align-content: center;
-  padding-left: 12em;
+}
+@media screen and (max-width: 450px){
+	.pie-chart{
+		display: block;
+	}
+	
 }

--- a/src/components/SkillUsageCard/SkillUsage.css
+++ b/src/components/SkillUsageCard/SkillUsage.css
@@ -42,9 +42,3 @@
   justify-content: center;
   align-content: center;
 }
-@media screen and (max-width: 450px){
-	.pie-chart{
-		display: block;
-	}
-	
-}

--- a/src/components/SkillUsageCard/SkillUsage.css
+++ b/src/components/SkillUsageCard/SkillUsage.css
@@ -41,4 +41,5 @@
   display: flex;
   justify-content: center;
   align-content: center;
+  padding-left: 12em;
 }


### PR DESCRIPTION
Fixes #1621 #1627 

Changes: Code added to align the device wise usage chart properly with the size of the screen.

Surge Deployment Link: https://pr-1623-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

![2018-10-07 1](https://user-images.githubusercontent.com/31557923/46578304-95717000-ca1a-11e8-829f-612c244ff807.png)
![2018-10-07 2](https://user-images.githubusercontent.com/31557923/46578306-9b675100-ca1a-11e8-94c0-3cd87494c3c6.png)
![2018-10-07 3](https://user-images.githubusercontent.com/31557923/46578307-a02c0500-ca1a-11e8-8538-b0464cd080f1.png)
![2018-10-07](https://user-images.githubusercontent.com/31557923/46578309-a4f0b900-ca1a-11e8-862b-877760140789.png)

