### PR TITLE
Button text is now visible in Botwizard

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -680,6 +680,8 @@ class BotWizard extends React.Component {
                     <div style={{ float: 'left', paddingTop: '20px' }}>
                       <RaisedButton
                         label="Save Draft"
+                        backgroundColor={colors.header}
+                        labelColor="#fff"
                         onTouchTap={this.saveDraft}
                       />
                     </div>
@@ -720,6 +722,8 @@ class BotWizard extends React.Component {
                   {this.state.stepIndex < 2 ? (
                     <RaisedButton
                       label="Save Draft"
+                      backgroundColor={colors.header}
+                      labelColor="#fff"
                       onTouchTap={this.saveDraft}
                     />
                   ) : null}
@@ -739,7 +743,11 @@ class BotWizard extends React.Component {
                     ) : null}
                     {stepIndex === 0 ? (
                       <Link to="/botbuilder">
-                        <RaisedButton label="Cancel" />
+                        <RaisedButton
+                          label="Cancel"
+                          backgroundColor={colors.header}
+                          labelColor="#fff"
+                        />
                       </Link>
                     ) : null}
                   </div>


### PR DESCRIPTION
Fixes #1615 

Changes: Label and background colour of 'Save draft' and 'Cancel' buttons has changed.

Surge Deployment Link: https://pr-1624-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot 2018-10-08 at 3 30 46 pm](https://user-images.githubusercontent.com/31539812/46602902-2de91c80-cb0f-11e8-9607-bb4a189c40e8.png)




