### PR TITLE
Preview section is fixed when window is scrolled

### DIFF
--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -759,7 +759,9 @@ class BotWizard extends React.Component {
                 md={this.state.colPreview}
                 style={{
                   display: this.state.colPreview === 0 ? 'none' : 'block',
-                  paddingTop: '25px',
+                  position: 'fixed',
+                  marginLeft: '65%',
+                  bottom: '6px',
                 }}
               >
                 <Paper

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -761,11 +761,19 @@ class BotWizard extends React.Component {
                   display: this.state.colPreview === 0 ? 'none' : 'block',
                   position: 'fixed',
                   marginLeft: '65%',
-                  bottom: '6px',
+                  height: '88%',
+                  marginTop: '10px',
                 }}
               >
                 <Paper
-                  style={styles.paperStyle}
+                  style={
+                    (styles.paperStyle,
+                    {
+                      height: '99.9%',
+                      marginTop: '20px',
+                      position: 'relative',
+                    })
+                  }
                   className="botBuilder-page-card"
                   zDepth={1}
                 >


### PR DESCRIPTION
Fixes #1616 

Changes: When the page is scrolled the preview section is fixed .

Surge Deployment Link: https://pr-1625-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![preview1](https://user-images.githubusercontent.com/32234926/46608029-e1a6d800-cb20-11e8-8590-d0760b01723e.gif)

