### PR TITLE
use_user_settings_for_theme

### DIFF
--- a/src/components/BotBuilder/BotBuilder.js
+++ b/src/components/BotBuilder/BotBuilder.js
@@ -10,7 +10,7 @@ import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import { FloatingActionButton, Paper } from 'material-ui';
 import './BotBuilder.css';
-import { urls, colors } from '../../utils';
+import { urls } from '../../utils';
 import { Link } from 'react-router-dom';
 import Cookies from 'universal-cookie';
 import * as $ from 'jquery';
@@ -153,7 +153,7 @@ class BotBuilder extends React.Component {
                 label={bot.name}
                 labelPosition="before"
                 labelStyle={{ verticalAlign: 'middle' }}
-                backgroundColor={colors.header}
+                secondary={true}
                 labelColor="#fff"
               />
             </Link>
@@ -244,7 +244,7 @@ class BotBuilder extends React.Component {
                 label={drafts[draft].name === '' ? draft : drafts[draft].name}
                 labelPosition="before"
                 labelStyle={{ verticalAlign: 'middle' }}
-                backgroundColor={colors.header}
+                secondary={true}
                 labelColor="#fff"
               />
             </Link>
@@ -346,7 +346,7 @@ class BotBuilder extends React.Component {
                     >
                       <RaisedButton
                         label={template.name}
-                        backgroundColor={colors.header}
+                        secondary={true}
                         labelColor="#fff"
                       />
                     </Card>
@@ -367,7 +367,7 @@ class BotBuilder extends React.Component {
               <Link to="/botbuilder/botwizard">
                 <Card className="bot-template-card">
                   <FloatingActionButton
-                    backgroundColor={colors.fabButton}
+                    secondary={true}
                     mini={true}
                     style={{
                       boxShadow:
@@ -403,7 +403,7 @@ class BotBuilder extends React.Component {
               label="Cancel"
               onClick={this.closeDeleteAlert}
               key={'Cancel'}
-              primary={true}
+              secondary={true}
               style={{ marginRight: '10px' }}
             />,
             <FlatButton

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -16,7 +16,7 @@ import Snackbar from 'material-ui/Snackbar';
 import { Paper, TextField } from 'material-ui';
 import ChevronLeft from 'material-ui/svg-icons/navigation/chevron-left';
 import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
-import { urls, colors, avatars } from '../../utils';
+import { urls, avatars } from '../../utils';
 import Icon from 'antd/lib/icon';
 import * as $ from 'jquery';
 import Cookies from 'universal-cookie';
@@ -694,7 +694,7 @@ class BotWizard extends React.Component {
                     {stepIndex < 2 ? (
                       <RaisedButton
                         label={'Next'}
-                        backgroundColor={colors.header}
+                        secondary={true}
                         labelColor="#fff"
                         onTouchTap={this.handleNext}
                       />
@@ -711,7 +711,7 @@ class BotWizard extends React.Component {
                             'Save and Deploy'
                           )
                         }
-                        backgroundColor={colors.header}
+                        secondary={true}
                         labelColor="#fff"
                         onTouchTap={this.saveClick}
                       />
@@ -732,7 +732,7 @@ class BotWizard extends React.Component {
                     {stepIndex !== 0 && stepIndex !== 3 ? (
                       <RaisedButton
                         label="Back"
-                        backgroundColor={colors.header}
+                        secondary={true}
                         labelColor="#fff"
                         onTouchTap={this.handlePrev}
                       />

--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -27,7 +27,7 @@ import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import SkillCardList from '../SkillCardList/SkillCardList';
 import SkillCardGrid from '../SkillCardGrid/SkillCardGrid';
 import SkillCardScrollList from '../SkillCardScrollList/SkillCardScrollList';
-import { urls, colors } from '../../utils';
+import { urls } from '../../utils';
 import Footer from '../Footer/Footer.react';
 import SearchBar from 'material-ui-search-bar';
 import _ from 'lodash';
@@ -487,7 +487,7 @@ export default class BrowseSkill extends React.Component {
                     }}
                     label="Create"
                     icon={<Add />}
-                    backgroundColor="#4285f4"
+                    secondary={true}
                     labelStyle={{ color: '#fff' }}
                   />
                 }
@@ -769,12 +769,6 @@ export default class BrowseSkill extends React.Component {
                   listStyle={{
                     top: '100px',
                   }}
-                  selectedMenuItemStyle={{
-                    color: colors.header,
-                  }}
-                  underlineFocusStyle={{
-                    color: colors.header,
-                  }}
                 >
                   <MenuItem
                     value={
@@ -865,12 +859,6 @@ export default class BrowseSkill extends React.Component {
                 style={styles.selection}
                 listStyle={{
                   top: '100px',
-                }}
-                selectedMenuItemStyle={{
-                  color: colors.header,
-                }}
-                underlineFocusStyle={{
-                  color: colors.header,
                 }}
                 multiple={true}
                 hintText="Languages"

--- a/src/components/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/SkillCardScrollList/SkillCardScrollList.js
@@ -280,18 +280,18 @@ class SkillCardScrollList extends Component {
           >
             <FloatingActionButton
               mini={true}
-              backgroundColor={'#4285f4'}
               style={leftFabStyle}
               onClick={this.scrollLeft}
+              secondary={true}
             >
               <NavigationChevronLeft />
             </FloatingActionButton>
             {this.state.cards}
             <FloatingActionButton
               mini={true}
-              backgroundColor={'#4285f4'}
               style={rightFabStyle}
               onClick={this.scrollRight}
+              secondary={true}
             >
               <NavigationChevronRight />
             </FloatingActionButton>

--- a/src/components/SkillCreator/SkillCreator.js
+++ b/src/components/SkillCreator/SkillCreator.js
@@ -4,7 +4,7 @@ import CodeView from './SkillViews/CodeView';
 import ConversationView from './SkillViews/ConversationView';
 import TreeView from './SkillViews/TreeView';
 import Preview from '../BotBuilder/Preview/Preview';
-import { urls, colors } from '../../utils';
+import { urls } from '../../utils';
 import CircularProgress from 'material-ui/CircularProgress';
 import { Link } from 'react-router-dom';
 import ISO6391 from 'iso-639-1';
@@ -760,7 +760,7 @@ export default class SkillCreator extends Component {
                           <RaisedButton
                             label="Choose an Image"
                             labelPosition="before"
-                            backgroundColor={colors.header}
+                            secondary={true}
                             containerElement="label"
                             labelColor="#fff"
                           >
@@ -843,7 +843,7 @@ export default class SkillCreator extends Component {
                             'Save'
                           )
                         }
-                        backgroundColor={colors.header}
+                        secondary={true}
                         labelColor="#fff"
                         style={{ marginLeft: 10 }}
                         onTouchTap={this.saveClick}
@@ -851,7 +851,7 @@ export default class SkillCreator extends Component {
                       <Link to="/">
                         <RaisedButton
                           label="Cancel"
-                          backgroundColor={colors.header}
+                          secondary={true}
                           labelColor="#fff"
                           style={{ marginLeft: 10 }}
                         />

--- a/src/components/SkillEditor/SkillEditor.js
+++ b/src/components/SkillEditor/SkillEditor.js
@@ -28,7 +28,7 @@ import * as $ from 'jquery';
 import notification from 'antd/lib/notification';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import { red500 } from 'material-ui/styles/colors';
-import { urls, colors } from '../../utils';
+import { urls } from '../../utils';
 const groups = [];
 const languages = [];
 const fontsizes = [];
@@ -933,7 +933,7 @@ class SkillEditor extends Component {
                 <RaisedButton
                   label="Choose an Image"
                   labelPosition="before"
-                  backgroundColor={colors.header}
+                  secondary={true}
                   containerElement="label"
                   labelColor="#fff"
                 >
@@ -1039,7 +1039,7 @@ class SkillEditor extends Component {
               <RaisedButton
                 label={this.state.loading ? 'Saving' : 'Save'}
                 disabled={this.state.loading}
-                backgroundColor={colors.header}
+                secondary={true}
                 labelColor="#fff"
                 style={{ marginLeft: 10 }}
                 onTouchTap={this.saveClick}
@@ -1057,7 +1057,7 @@ class SkillEditor extends Component {
               >
                 <RaisedButton
                   label="Cancel"
-                  backgroundColor={colors.header}
+                  secondary={true}
                   labelColor="#fff"
                   style={{ marginLeft: 10 }}
                 />

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -865,10 +865,7 @@ class SkillListing extends Component {
                     },
                   }}
                 >
-                  <FloatingActionButton
-                    data-tip="Edit Skill"
-                    backgroundColor={colors.header}
-                  >
+                  <FloatingActionButton data-tip="Edit Skill" secondary={true}>
                     <EditBtn />
                   </FloatingActionButton>
                   <ReactTooltip effect="solid" place="bottom" />
@@ -889,7 +886,7 @@ class SkillListing extends Component {
                   <div className="skillVersionBtn">
                     <FloatingActionButton
                       data-tip="Skill Versions"
-                      backgroundColor={colors.header}
+                      secondary={true}
                     >
                       <VersionBtn />
                     </FloatingActionButton>

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -20,7 +20,7 @@ import CircleImage from '../CircleImage/CircleImage';
 import MenuItem from 'material-ui/MenuItem';
 import { Link } from 'react-router-dom';
 import susiWhite from '../../images/SUSIAI-white.png';
-import { urls, colors, isProduction } from '../../utils';
+import { urls, isProduction } from '../../utils';
 import $ from 'jquery';
 import './StaticAppBar.css';
 // import ListUser from '../Admin/ListUser/ListUser';
@@ -190,10 +190,6 @@ class StaticAppBar extends Component {
   closeAuthDialog = () => this.setState({ showAuth: false });
 
   render() {
-    const headerStyle = {
-      background: colors.header,
-    };
-
     const isLoggedIn = !!cookies.get('loggedIn');
     let avatarProps = null;
     if (isLoggedIn) {
@@ -311,7 +307,7 @@ class StaticAppBar extends Component {
 
     return (
       <div>
-        <header className="nav-down" style={headerStyle} id="headerSection">
+        <header className="nav-down" id="headerSection">
           <AppBar
             className="topAppBar"
             id="appBar"
@@ -331,7 +327,6 @@ class StaticAppBar extends Component {
               </div>
             }
             style={{
-              backgroundColor: colors.header,
               height: '46px',
               boxShadow: 'none',
               margin: '0 auto',

--- a/src/index.js
+++ b/src/index.js
@@ -31,104 +31,184 @@ import BotBuilderWrap from './components/BotBuilder/BotBuilderWrap';
 import setDefaults from './DefaultSettings';
 import BrowseSkillByCategory from './components/BrowseSkill/BrowseSkillByCategory';
 import BrowseSkillByLanguage from './components/BrowseSkill/BrowseSkillByLanguage';
-import { colors } from './utils';
+import Cookies from 'universal-cookie';
+import { urls } from './utils';
+import $ from 'jquery';
 
 setDefaults();
 
 injectTapEventPlugin();
 
-const muiTheme = getMuiTheme({
-  appBar: {
-    color: colors.primary,
+const cookies = new Cookies();
+
+let lightTheme = {
+  palette: {
+    primary1Color: '#4285f4',
+    accent1Color: '#4285f4',
+    textColor: '#000',
+    backgroundColor: '#fff',
   },
-  checkbox: {
-    checkedColor: colors.primary,
+};
+
+let darkTheme = {
+  palette: {
+    primary1Color: '#19324c',
+    accent1Color: '#19324c',
+    textColor: '#fff',
+    canvasColor: '#3F51B5',
+    backgroundColor: '#303030',
   },
-  stepper: {
-    iconColor: colors.primary,
-  },
-  radioButton: {
-    backgroundColor: '#ffffff',
-    borderColor: colors.primary,
-    checkedColor: colors.primary,
-  },
-  raisedButton: {
-    primaryColor: colors.primary,
-    primaryTextColor: '#ffffff',
-    textColor: '#ffffff',
-  },
-  flatButton: {
-    color: '#FFFFFF',
-    primaryTextColor: colors.primary,
-    textColor: colors.primary,
-  },
-});
+};
 
 class App extends React.Component {
+  state = {
+    muiTheme: {
+      ...lightTheme,
+    },
+  };
+
+  componentDidMount() {
+    if (cookies.get('loggedIn')) {
+      $.ajax({
+        url:
+          urls.API_URL +
+          '/aaa/listUserSettings.json?access_token=' +
+          cookies.get('loggedIn'),
+        dataType: 'jsonp',
+        jsonp: 'callback',
+        crossDomain: true,
+        success: function(data) {
+          let themeValue = { theme: 'light' };
+          if (data.settings && data.settings.theme) {
+            themeValue = { theme: data.settings.theme };
+            if (
+              data.settings.theme === 'custom' &&
+              data.settings.customThemeValue
+            ) {
+              let customThemeValues = data.settings.customThemeValue.split(',');
+              themeValue.customThemeValue = customThemeValues;
+            }
+          }
+          if (themeValue.customThemeValue) {
+            let palette = {
+              primary1Color: '#' + themeValue.customThemeValue[0],
+              accent1Color: '#' + themeValue.customThemeValue[5],
+              textColor: this.invertColorTextArea(
+                '#' + themeValue.customThemeValue[2],
+              ),
+              backgroundColor: '#' + themeValue.customThemeValue[2],
+            };
+            this.setState({
+              muiTheme: { palette },
+            });
+          } else if (themeValue.theme === 'dark') {
+            this.setState({
+              muiTheme: {
+                ...darkTheme,
+              },
+            });
+          }
+        }.bind(this),
+        error: function(errorThrown) {
+          console.log(errorThrown);
+        },
+      });
+    }
+  }
+
+  invertColorTextArea = hex => {
+    // get the text are code
+    hex = hex.slice(1);
+
+    // convert 3-digit hex to 6-digits.
+    if (hex.length === 3) {
+      hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2];
+    }
+    if (hex.length !== 6) {
+      throw new Error('Invalid HEX color.');
+    }
+    var r = parseInt(hex.slice(0, 2), 16),
+      g = parseInt(hex.slice(2, 4), 16),
+      b = parseInt(hex.slice(4, 6), 16);
+
+    return r * 0.299 + g * 0.587 + b * 0.114 > 186 ? '#000000' : '#FFFFFF';
+  };
+
   render() {
     return (
-      <Router>
-        <MuiThemeProvider muiTheme={muiTheme}>
-          <Switch>
-            <Route
-              exact
-              path="/:category/:skill/edit/:lang"
-              component={SkillEditor}
-            />
-            <Route
-              exact
-              path="/:category/:skill/edit/:lang/:commit"
-              component={SkillEditor}
-            />
-            <Route exact path="/admin" component={Admin} />
-            <Route exact path="/admin/users" component={Users} />
-            <Route exact path="/admin/skills" component={Skills} />
-            <Route exact path="/admin/settings" component={SystemSettings} />
-            <Route exact path="/admin/logs" component={SystemLogs} />
-            <Route
-              exact
-              path="/:category/:skill/:lang"
-              component={SkillListing}
-            />
-            <Route
-              exact
-              path="/:category/:skill/:lang/feedbacks"
-              component={SkillFeedbackPage}
-            />
-            <Route path="/botbuilder" component={BotBuilderWrap} />
-            <Route exact path="/dashboard" component={Dashboard} />
-            <Route exact path="/logout" component={Logout} />
-            <Route exact path="/skillCreator" component={SkillCreator} />
-            <Route
-              exact
-              path="/:category/:skill/versions/:lang"
-              component={SkillVersion}
-            />
-            <Route
-              exact
-              path="/:category/:skill/compare/:lang/:oldid/:recentid"
-              component={SkillHistory}
-            />
-            <Route
-              exact
-              path="/:category/:skill/edit/:lang/:latestid/:revertid"
-              component={SkillRollBack}
-            />
-            <Route
-              exact
-              path="/category/:category"
-              component={BrowseSkillByCategory}
-            />
-            <Route
-              exact
-              path="/language/:language"
-              component={BrowseSkillByLanguage}
-            />
-            <Route exact path="/" component={BrowseSkill} />
-            <Route exact path="*" component={NotFound} />
-          </Switch>
-        </MuiThemeProvider>
-      </Router>
+      <div
+        style={{
+          backgroundColor: this.state.muiTheme.palette.backgroundColor,
+          color: this.state.muiTheme.palette.textColor,
+          position: 'fixed',
+          overflowY: 'scroll',
+          width: '100%',
+          height: '100%',
+        }}
+      >
+        <Router>
+          <MuiThemeProvider muiTheme={getMuiTheme({ ...this.state.muiTheme })}>
+            <Switch>
+              <Route
+                exact
+                path="/:category/:skill/edit/:lang"
+                component={SkillEditor}
+              />
+              <Route
+                exact
+                path="/:category/:skill/edit/:lang/:commit"
+                component={SkillEditor}
+              />
+              <Route exact path="/admin" component={Admin} />
+              <Route exact path="/admin/users" component={Users} />
+              <Route exact path="/admin/skills" component={Skills} />
+              <Route exact path="/admin/settings" component={SystemSettings} />
+              <Route exact path="/admin/logs" component={SystemLogs} />
+              <Route
+                exact
+                path="/:category/:skill/:lang"
+                component={SkillListing}
+              />
+              <Route
+                exact
+                path="/:category/:skill/:lang/feedbacks"
+                component={SkillFeedbackPage}
+              />
+              <Route path="/botbuilder" component={BotBuilderWrap} />
+              <Route exact path="/dashboard" component={Dashboard} />
+              <Route exact path="/logout" component={Logout} />
+              <Route exact path="/skillCreator" component={SkillCreator} />
+              <Route
+                exact
+                path="/:category/:skill/versions/:lang"
+                component={SkillVersion}
+              />
+              <Route
+                exact
+                path="/:category/:skill/compare/:lang/:oldid/:recentid"
+                component={SkillHistory}
+              />
+              <Route
+                exact
+                path="/:category/:skill/edit/:lang/:latestid/:revertid"
+                component={SkillRollBack}
+              />
+              <Route
+                exact
+                path="/category/:category"
+                component={BrowseSkillByCategory}
+              />
+              <Route
+                exact
+                path="/language/:language"
+                component={BrowseSkillByLanguage}
+              />
+              <Route exact path="/" component={BrowseSkill} />
+              <Route exact path="*" component={NotFound} />
+            </Switch>
+          </MuiThemeProvider>
+        </Router>
+      </div>
     );
   }
 }


### PR DESCRIPTION
Fixes #1618 

Changes: User settings are now used to change theme of the app. User settings are fetched on app load and theme colors are passed in the muiThemeProvider which changes the theme of the app.

Now there is no need to specify background-color of the components by using utills/colors.js like:
```
              <RaisedButton
                label={bot.name}
                labelPosition="before"
                labelStyle={{ verticalAlign: 'middle' }}
                backgroundColor={colors.header}
                labelColor="#fff"
              />
```
Instead just primary={true} or secondary={true} props can be passed like:
```
              <RaisedButton
                label={bot.name}
                labelPosition="before"
                labelStyle={{ verticalAlign: 'middle' }}
                backgroundColor={colors.header}
                labelColor="#fff"
              />
```
By making this change the colors of components can be changed dynamically and hence the entire theme can be changed by the primaryColor or accentColor from the muiThemeProvider. Here i have used accentColor for button color and primaryColor for header color so all buttons need to have secondary={true} prop and components having primary={true} would have primaryColor.

At some palces on certain theme colors some texts or components might not be clearly visible, i think different issues should be raised for that as those issues would specific to those components only.  

Surge Deployment Link: https://pr-[ADD_PULL_REQUEST_NUMBER_HERE]-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/21025052/46858089-22a43280-ce28-11e8-8270-4427916b33d4.gif)
