### PR TITLE
when screen is squeezed preview section does not overlap

### DIFF
--- a/src/components/BotBuilder/BotBuilder.css
+++ b/src/components/BotBuilder/BotBuilder.css
@@ -299,6 +299,14 @@ input[type=file]{
 	}
 }
 
+@media  (max-width:769px){
+	.botbuilder-col{
+		position: inherit !important ;
+		margin-left: 0px !important ;
+		margin-bottom: 40px;
+	}
+}
+
 .preview-button {
 	height: 45px;
 	width: 42px;

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -20,6 +20,7 @@ import { urls, colors, avatars } from '../../utils';
 import Icon from 'antd/lib/icon';
 import * as $ from 'jquery';
 import Cookies from 'universal-cookie';
+import './BotBuilder.css';
 
 const cookies = new Cookies();
 
@@ -783,6 +784,7 @@ class BotWizard extends React.Component {
                       height: '99.9%',
                       marginTop: '20px',
                       position: 'relative',
+                      marginRight: '30px',
                     })
                   }
                   className="botBuilder-page-card"


### PR DESCRIPTION
Fixes #1630 

Changes: When the screen is squeezed the preview section would go at the bottom of the page.
               https://skills.susi.ai/botbuilder/botwizard

Surge Deployment Link: https://pr-1631-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![preview1](https://user-images.githubusercontent.com/32234926/46967217-88651880-d0cd-11e8-880b-4bf7a7bef432.gif)

