### PR TITLE
Background colour of 'Reset Changes' button is changed

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/DesignViews/UIView.js
+++ b/src/components/BotBuilder/BotBuilderPages/DesignViews/UIView.js
@@ -725,6 +725,7 @@ class UIView extends Component {
           <div className="design-box">
             {this.state.loadedSettings && <Grid>{customizeComponents}</Grid>}
             <RaisedButton
+              backgroundColor={colors.header}
               label={
                 this.state.resetting ? (
                   <CircularProgress color={colors.header} size={32} />


### PR DESCRIPTION
Fixes #1646 

Changes: Background colour of 'Reset Changes' button is changed in UI view of Design Section of Bot Creator.

Surge Deployment Link: https://pr-[ADD_PULL_REQUEST_NUMBER_HERE]-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

![screenshot 2018-10-25 at 10 58 33 am](https://user-images.githubusercontent.com/31539812/47477974-58dcab80-d845-11e8-88e4-cf82118c7394.png)
