### PR TITLE
navigation button when clicked reached to top of the window

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -191,6 +191,7 @@ export default class BrowseSkill extends React.Component {
   };
 
   handleNavigationForward = () => {
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
     let listPage = this.state.listPage + 1;
     let listOffset = this.state.listOffset + this.state.entriesPerPage;
     this.setState({
@@ -204,6 +205,7 @@ export default class BrowseSkill extends React.Component {
   };
 
   handleNavigationBackward = () => {
+    $('html, body').animate({ scrollTop: 0 }, 'fast');
     let listPage = this.state.listPage - 1;
     let listOffset = this.state.listOffset - this.state.entriesPerPage;
     this.setState({


### PR DESCRIPTION
Fixes #1661 

Changes: After searching when user clicks on the navigation button user should reach the top of the window and also to the next page.

Surge Deployment Link: https://pr-1662-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![scrolltop](https://user-images.githubusercontent.com/32234926/47832859-da8c8600-ddbd-11e8-98b5-cfc23a873f75.gif)

