### PR TITLE
Back button added in Skill listing page

### DIFF
--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -20,6 +20,7 @@ import Snackbar from 'material-ui/Snackbar';
 import FlatButton from 'material-ui/FlatButton';
 import TextField from 'material-ui/TextField';
 import Ratings from 'react-ratings-declarative';
+import NavigationArrowBack from 'material-ui/svg-icons/navigation/arrow-back';
 
 // Static Assets
 import 'brace/mode/markdown';
@@ -844,6 +845,19 @@ class SkillListing extends Component {
                   </Dialog>
                 </div>
               )}
+              <div>
+                <a href="https://skills.susi.ai">
+                  <div className="skillVersionBtn">
+                    <FloatingActionButton
+                      data-tip="Back"
+                      backgroundColor={colors.header}
+                    >
+                      <NavigationArrowBack />
+                    </FloatingActionButton>
+                    <ReactTooltip effect="solid" place="bottom" />
+                  </div>
+                </a>
+              </div>
               <div>
                 <Link
                   to={{


### PR DESCRIPTION
Fixes #1663 

Changes: Back buttton is added in skill listing page, using which user can go back to skills page after checking out a skill.

Surge Deployment Link: https://pr-1664-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot 2018-11-02 at 2 20 46 pm](https://user-images.githubusercontent.com/31539812/47906976-5830be80-deb0-11e8-9b2c-dfe2c3f31757.png)
