### PR TITLE
SkillCard links fixed

### DIFF
--- a/src/components/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/SkillCardScrollList/SkillCardScrollList.js
@@ -201,7 +201,7 @@ class SkillCardScrollList extends Component {
                   '/' +
                   skill.skill_tag +
                   '/' +
-                  this.props.languageValue,
+                  skill.language,
                 state: {
                   url: this.props.skillUrl,
                   element: el,
@@ -234,7 +234,7 @@ class SkillCardScrollList extends Component {
                   '/' +
                   skill.skill_tag +
                   '/' +
-                  this.props.languageValue +
+                  skill.language +
                   '/feedbacks',
                 state: {
                   url: this.props.skillUrl,


### PR DESCRIPTION
Fixes #1682 

Changes: I have fixed the issue by fixing the links that the cards led to.

Surge Deployment Link: https://pr-[ADD_PULL_REQUEST_NUMBER_HERE]-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

Before:
![ezgif-1-ef2b90891b2a](https://user-images.githubusercontent.com/19551058/48438280-9fb92380-e7a9-11e8-96ea-582ec76d6465.gif)

After:
![ezgif-1-966d6c22f22a](https://user-images.githubusercontent.com/19551058/48438286-a5af0480-e7a9-11e8-919b-6e2a1abf62e9.gif)

