### PR TITLE
staticAppBar: fix post login screen error

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -126,7 +126,7 @@ class StaticAppBar extends Component {
   componentDidMount() {
     window.addEventListener('scroll', this.handleScroll);
     if (cookies.get('loggedIn')) {
-      this.initializeAdminService();
+      this.initializeShowAdminService();
       this.initializeListUserSettings();
     }
 


### PR DESCRIPTION
Fixes #1693 

Changes: Currently after logging in, the screen is always in loading state, which should not be so.

Surge Deployment Link: https://pr-1694-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/31389740/49075906-ce310700-f25d-11e8-9833-a74fe5914745.png)
