### PR TITLE
Fixes #1699 : Fixes the bug which shows right scroll arrow even if th…

### DIFF
--- a/src/components/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/SkillCardScrollList/SkillCardScrollList.js
@@ -266,6 +266,9 @@ class SkillCardScrollList extends Component {
         </Card>,
       );
     });
+    if (cards.length <= this.state.scrollCards) {
+      this.setState({ rightBtnDisplay: 'none' });
+    }
     this.setState({
       cards,
     });


### PR DESCRIPTION
Fixes #1699

Changes: I provided a condition checker which checks if cards array length is equal to or smaller than scrollCards limit..and if it is smaller or equal it doesn't show right arrow

Screenshots for the change:
Before the change:-
![screenshot 2018-12-02 at 11 29 37 pm](https://user-images.githubusercontent.com/30868400/49368502-daf9a300-f714-11e8-8530-40b8c783c166.png)

After the change:-
![screenshot 2018-12-03 at 2 04 07 am](https://user-images.githubusercontent.com/30868400/49368512-dfbe5700-f714-11e8-8c3c-9dcef2331e1c.png)

PS- Had some git issues that's why had to close the last PR and opened a new one with all your suggestions @akshatnitd 