### PR TITLE
Image upload button only accepts images in skill creator

### DIFF
--- a/src/components/BotBuilder/BotBuilderPages/DesignViews/UIView.js
+++ b/src/components/BotBuilder/BotBuilderPages/DesignViews/UIView.js
@@ -623,7 +623,7 @@ class UIView extends Component {
                           disabled={this.state.uploadingBodyBackgroundImg}
                           type="file"
                           onChange={this.handleChangeBodyBackgroundImage}
-                          accept="image/x-png,image/gif,image/jpeg"
+                          accept="image/*"
                         />
                         {this.state.uploadingBodyBackgroundImg ? (
                           <CircularProgress color="#ffffff" size={32} />

--- a/src/components/SkillCreator/SkillCreator.js
+++ b/src/components/SkillCreator/SkillCreator.js
@@ -1268,6 +1268,7 @@ export default class SkillCreator extends Component {
                                   style={styles.uploadCircularButton}
                                 >
                                   <input
+                                    accept="image/*"
                                     type="file"
                                     ref={c => {
                                       this.file = c;
@@ -1295,6 +1296,7 @@ export default class SkillCreator extends Component {
                               >
                                 <input
                                   type="file"
+                                  accept="image/*"
                                   style={{
                                     cursor: 'pointer',
                                     position: 'absolute',


### PR DESCRIPTION
Fixes #1707 

Changes: [Add here what changes were made in this issue and if possible provide links.]
Image upload button only accepts images in skill creator

Surge Deployment Link: https://pr-1708-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot 2018-12-05 at 3 35 22 pm](https://user-images.githubusercontent.com/31539812/49506785-f09dd280-f8a4-11e8-821a-0bf8dfdc1b9b.png)
