### PR TITLE
Fix bug with preview of public skill creator

### DIFF
--- a/src/components/BotBuilder/Preview/Preview.js
+++ b/src/components/BotBuilder/Preview/Preview.js
@@ -166,11 +166,13 @@ class Preview extends Component {
   send = text => {
     let url = urls.API_URL + '/susi/chat.json?q=' + encodeURIComponent(text);
     url += '&instant=' + encodeURIComponent(this.props.skill);
-    const enableDefaultSkillsMatch = this.props.configCode.match(
-      /^::enable_default_skills\s(.*)$/m,
-    );
-    if (enableDefaultSkillsMatch && enableDefaultSkillsMatch[1] === 'no') {
-      url += '&excludeDefaultSkills=true';
+    if (this.props.botBuilder) {
+      const enableDefaultSkillsMatch = this.props.configCode.match(
+        /^::enable_default_skills\s(.*)$/m,
+      );
+      if (enableDefaultSkillsMatch && enableDefaultSkillsMatch[1] === 'no') {
+        url += '&excludeDefaultSkills=true';
+      }
     }
     const thisMsgNumber = this.msgNumber;
     this.msgNumber++;


### PR DESCRIPTION
Fixes #1704 

Changes: Preview of public skill creator was non-functional due to a minor bug. This PR fixes it.

Surge Deployment Link: https://pr-1729-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

<img width="958" alt="screenshot 2018-12-13 at 8 22 20 pm" src="https://user-images.githubusercontent.com/31174685/49946517-2a11b600-ff15-11e8-8c76-dae801603bf5.png">

