### PR TITLE
display template image for a template bot as default

### DIFF
--- a/src/components/BotBuilder/BotBuilder.js
+++ b/src/components/BotBuilder/BotBuilder.js
@@ -111,24 +111,24 @@ class BotBuilder extends React.Component {
     if (bots) {
       bots.forEach(bot => {
         let imageUrl;
-        if (bot.image !== 'images/<image_name>') {
-          imageUrl = bot.image
-            ? BASE_URL +
-              '/cms/getImage.png?access_token=' +
-              cookies.get('loggedIn') +
-              '&language=' +
-              bot.language +
-              '&group=' +
-              bot.group.replace(/ /g, '%20') +
-              '&image=' +
-              bot.image.replace(/ /g, '%20')
-            : null;
+        let { protocol, host } = window.location;
+        if (bot.image === 'images/<image_name>') {
+          imageUrl = `${protocol}//${host}/customAvatars/1.png`;
+        } else if (bot.image === 'images/<image_name_event>') {
+          imageUrl = `${protocol}//${host}/botTemplates/event-registration.jpg`;
+        } else if (bot.image === 'images/<image_name_job>') {
+          imageUrl = `${protocol}//${host}/botTemplates/job-application.jpg`;
+        } else if (bot.image === 'images/<image_name_contact>') {
+          imageUrl = `${protocol}//${host}/botTemplates/contact-us.png`;
         } else {
-          imageUrl =
-            window.location.protocol +
-            '//' +
-            window.location.host +
-            '/customAvatars/1.png';
+          imageUrl = bot.image
+            ? `${BASE_URL}/cms/getImage.png?access_token=${cookies.get(
+                'loggedIn',
+              )}&language=${bot.language}&group=${bot.group.replace(
+                / /g,
+                '%20',
+              )}&image=${bot.image.replace(/ /g, '%20')}`
+            : null;
         }
         chatbots.push(
           <Card

--- a/src/components/BotBuilder/BotBuilderWrap.js
+++ b/src/components/BotBuilder/BotBuilderWrap.js
@@ -15,7 +15,7 @@ const templates = [
     image: '/botTemplates/event-registration.jpg',
     // source: https://pixabay.com/en/event-auditorium-conference-1597531/
     code:
-      '::name <Bot_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image images/<image_name>\n::terms_of_use <link>\n\n\nWhat is your name? | What is your email? | Can you come to the event?\n!example: Jimmy | user@example.com | yes\n',
+      '::name <Bot_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image images/<image_name_event>\n::terms_of_use <link>\n\n\nWhat is your name? | What is your email? | Can you come to the event?\n!example: Jimmy | user@example.com | yes\n',
   },
   {
     name: 'Job Application',
@@ -23,7 +23,7 @@ const templates = [
     image: '/botTemplates/job-application.jpg',
     // source: https://pixabay.com/en/application-request-pen-coolie-1915343/
     code:
-      '::name <Bot_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image images/<image_name>\n::terms_of_use <link>\n\n\nWhat is your name? | Why do you want this job? | What are your skills?\n!example: Jimmy | It will be helpful for my career | Web developement\n',
+      '::name <Bot_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image images/<image_name_job>\n::terms_of_use <link>\n\n\nWhat is your name? | Why do you want this job? | What are your skills?\n!example: Jimmy | It will be helpful for my career | Web developement\n',
   },
   {
     name: 'Contact Form',
@@ -31,7 +31,7 @@ const templates = [
     image: '/botTemplates/contact-us.png',
     // source: https://pixabay.com/en/need-help-contact-us-idea-like-2939262/
     code:
-      '::name <Bot_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image images/<image_name>\n::terms_of_use <link>\n\n\nWhat is your name? | What is your email? | What is your message?\n!example: Jimmy | user@example.com | i want to know about sales\n',
+      '::name <Bot_name>\n::category <Category>\n::language <Language>\n::author <author_name>\n::author_url <author_url>\n::description <description> \n::dynamic_content <Yes/No>\n::developer_privacy_policy <link>\n::image images/<image_name_contact>\n::terms_of_use <link>\n\n\nWhat is your name? | What is your email? | What is your message?\n!example: Jimmy | user@example.com | i want to know about sales\n',
   },
 ];
 

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -228,12 +228,24 @@ class BotWizard extends React.Component {
             .split('::bodyBackground')[0];
         const imageNameMatch = buildCode.match(/^::image\s(.*)$/m);
         let imagePreviewUrl;
-        if (imageNameMatch[1] !== 'images/<image_name>') {
+        let localImages = [
+          'images/<image_name>',
+          'images/<image_name_event>',
+          'images/<image_name_job>',
+          'images/<image_name_contact>',
+        ];
+        if (!localImages.includes(imageNameMatch[1])) {
           imagePreviewUrl = `${
             urls.API_URL
           }/cms/getImage.png?access_token=${cookies.get(
             'loggedIn',
           )}&language=${language}&group=${group}&image=${imageNameMatch[1]}`;
+        } else if (imageNameMatch[1] === 'images/<image_name_event>') {
+          imagePreviewUrl = '/botTemplates/event-registration.jpg';
+        } else if (imageNameMatch[1] === 'images/<image_name_job>') {
+          imagePreviewUrl = '/botTemplates/job-application.jpg';
+        } else if (imageNameMatch[1] === 'images/<image_name_contact>') {
+          imagePreviewUrl = '/botTemplates/contact-us.png';
         } else {
           imagePreviewUrl = this.state.image;
         }
@@ -470,10 +482,13 @@ class BotWizard extends React.Component {
       });
       return 0;
     }
+    let imageUrl = this.state.imageUrl;
     if (
-      !new RegExp(/.+\.\w+/g).test(self.state.imageUrl) &&
-      self.state.imageUrl !== '<image_name>' &&
-      self.state.imageUrl !== 'images/<image_name>'
+      !new RegExp(/.+\.\w+/g).test(imageUrl) &&
+      imageUrl !== 'images/<image_name>' &&
+      imageUrl !== 'images/<image_name_event>' &&
+      imageUrl !== 'images/<image_name_job>' &&
+      imageUrl !== 'images/<image_name_contact>'
     ) {
       notification.open({
         message: 'Error Processing your Request',


### PR DESCRIPTION
Fixes #1695 

Changes: Currently for a template bot also, susi logo is being displayed by default. But, for a template bot, the corresponding template image should be displayed by default.

For eg, for an event bot, if no image is chosen by the user, by default, the image for event template should be displayed. Similarly for contact and job templates.

Surge Deployment Link: https://pr-1739-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:

![image](https://user-images.githubusercontent.com/31389740/50406490-d001d200-07eb-11e9-91b3-ab14a27712e1.png)

