### PR TITLE
added max-width to search bar

### DIFF
--- a/src/components/BrowseSkill/SkillStyle.js
+++ b/src/components/BrowseSkill/SkillStyle.js
@@ -167,6 +167,7 @@ const styles = {
     width: '100%',
     marginRight: '20px',
     flexShrink: '10',
+    maxWidth: '500px',
   },
   sortBy: {
     display: 'flex',


### PR DESCRIPTION
Fixes #1772 

Changes:

Added `max-width` attribute to search bar

Surge Deployment Link: https://pr-1772-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![image](https://user-images.githubusercontent.com/21276922/50690657-2248bb80-1054-11e9-8df3-6da95cb9ffc9.png)
Search bar doesn't overflow
