### PR TITLE
Fixes #1835: Password and confirm password now tightly coupled

### DIFF
--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -149,10 +149,14 @@ class SignUp extends Component {
         break;
       }
       case 'password': {
+        const { confirmPassword, passwordConfirmErrorMessage } = this.state;
         const password = event.target.value.trim();
         const passwordScore = zxcvbn(password).score;
         const strength = ['Worst', 'Bad', 'Weak', 'Good', 'Strong'];
         const passwordError = !(password.length >= 6 && password);
+        const passwordConfirmError =
+          (confirmPassword || passwordConfirmErrorMessage) &&
+          !(confirmPassword === password);
         this.setState({
           password,
           passwordErrorMessage: passwordError
@@ -160,6 +164,10 @@ class SignUp extends Component {
             : '',
           passwordScore: passwordError ? -1 : passwordScore,
           passwordStrength: passwordError ? '' : strength[passwordScore],
+          passwordConfirmErrorMessage: passwordConfirmError
+            ? 'Password does not match'
+            : '',
+          signupErrorMessage: '',
         });
         break;
       }


### PR DESCRIPTION
Fixes #1835 

Changes: The changes I have made are:
- [x] Passoword and confirmPassword field are now tightly coupled.

Surge Deployment Link: https://pr-1847-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![screenshot-localhost-3000-2019 01 19-19-51-28](https://user-images.githubusercontent.com/19551058/51427964-df760e80-1c23-11e9-9971-e8006ef0dbbf.png)

Note: To test this, put the password and confirm password correctly then delete characters from the password field. The error message should pop up in confirm password which ideally should be the expected behavior. 
