### PR TITLE
Fixes #1892: Signup error now shows if email ID is already taken

### DIFF
--- a/src/components/Auth/SignUp/SignUp.js
+++ b/src/components/Auth/SignUp/SignUp.js
@@ -258,8 +258,15 @@ class SignUp extends Component {
             password: '',
             loading: false,
           });
+          let snackBarMessage;
+          if (error.statusCode === 422) {
+            snackBarMessage =
+              'Already registered. Please signup with a different email account';
+          } else {
+            snackBarMessage = 'Signup Failed. Try Again';
+          }
           openSnackBar({
-            snackBarMessage: 'Signup Failed. Try Again',
+            snackBarMessage,
           });
         });
     }


### PR DESCRIPTION
Fixes #1892

Changes: The changes I have made are as follows:
- [x] Check for error status code and notify the user if an email ID is already taken.
- [x] Snackbar shows an error message if email ID is already taken.

Surge Deployment Link: https://pr-1923-fossasia-susi-skill-cms.surge.sh