### PR TITLE
Use app store to get user details instead of cookie #1876

### DIFF
--- a/src/__tests__/components/Admin/ListUser/ListUser.js
+++ b/src/__tests__/components/Admin/ListUser/ListUser.js
@@ -1,9 +1,17 @@
 import React from 'react';
 import ListUser from '../../../../components/Admin/ListUser/ListUser';
 import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe('<ListUser />', () => {
   it('render ListUser without crashing', () => {
-    shallow(<ListUser />);
+    shallow(
+      <Provider store={store}>
+        <ListUser />
+      </Provider>,
+    );
   });
 });

--- a/src/__tests__/components/Admin/SystemLogs/SystemLogs.js
+++ b/src/__tests__/components/Admin/SystemLogs/SystemLogs.js
@@ -1,9 +1,17 @@
 import React from 'react';
 import SystemLogs from '../../../../components/Admin/SystemLogs/SystemLogs';
 import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe('<SystemLogs />', () => {
   it('render SystemLogs without crashing', () => {
-    shallow(<SystemLogs />);
+    shallow(
+      <Provider store={store}>
+        <SystemLogs />
+      </Provider>,
+    );
   });
 });

--- a/src/__tests__/components/Admin/SystemSettings/SystemSettings.js
+++ b/src/__tests__/components/Admin/SystemSettings/SystemSettings.js
@@ -1,9 +1,17 @@
 import React from 'react';
 import SystemSettings from '../../../../components/Admin/SystemSettings/SystemSettings';
 import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe('<SystemSettings />', () => {
   it('render SystemSettings without crashing', () => {
-    shallow(<SystemSettings />);
+    shallow(
+      <Provider store={store}>
+        <SystemSettings />
+      </Provider>,
+    );
   });
 });

--- a/src/__tests__/components/BotBuilder/BotBuilderWrap.js
+++ b/src/__tests__/components/BotBuilder/BotBuilderWrap.js
@@ -1,9 +1,17 @@
 import React from 'react';
 import BotBuilderWrap from '../../../components/BotBuilder/BotBuilderWrap';
 import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe('<BotBuilderWrap />', () => {
   it('render BotBuilderWrap without crashing', () => {
-    shallow(<BotBuilderWrap />);
+    shallow(
+      <Provider store={store}>
+        <BotBuilderWrap />
+      </Provider>,
+    );
   });
 });

--- a/src/__tests__/components/Dashboard/Dashboard.js
+++ b/src/__tests__/components/Dashboard/Dashboard.js
@@ -1,9 +1,17 @@
 import React from 'react';
 import Dashboard from '../../../components/Dashboard/Dashboard';
 import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe('<Dashboard />', () => {
   it('render Dashboard without crashing', () => {
-    shallow(<Dashboard />);
+    shallow(
+      <Provider store={store}>
+        <Dashboard />
+      </Provider>,
+    );
   });
 });

--- a/src/__tests__/components/NotFound/NotFound.js
+++ b/src/__tests__/components/NotFound/NotFound.js
@@ -1,9 +1,17 @@
 import React from 'react';
 import NotFound from '../../../components/NotFound/NotFound.react';
 import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe('<NotFound />', () => {
   it('render NotFound without crashing', () => {
-    shallow(<NotFound />);
+    shallow(
+      <Provider store={store}>
+        <NotFound />
+      </Provider>,
+    );
   });
 });

--- a/src/__tests__/components/SkillCreator/SkillCreator.js
+++ b/src/__tests__/components/SkillCreator/SkillCreator.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import SkillCreator from '../../../components/SkillCreator/SkillCreator';
 import { shallow } from 'enzyme';
+import configureMockStore from 'redux-mock-store';
+import { Provider } from 'react-redux';
+const mockStore = configureMockStore();
+const store = mockStore({});
 
 describe('<SkillCreator />', () => {
   it('render SkillCreator without crashing', () => {
-    shallow(<SkillCreator />);
     shallow(
-      <SkillCreator location={{ pathname: '/:category/:skill/edit/:lang' }} />,
+      <Provider store={store}>
+        <SkillCreator location={{ pathname: '/:category/:skill/edit/:lang' }} />
+      </Provider>,
     );
   });
 });

--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -417,6 +417,7 @@ class ListSkills extends React.Component {
   };
 
   render() {
+    const { isAdmin } = this.props;
     const { groups, loading, skillName } = this.state;
 
     const editButtons = [
@@ -654,7 +655,7 @@ class ListSkills extends React.Component {
 
     return (
       <div>
-        {cookies.get('showAdmin') === 'true' ? (
+        {isAdmin ? (
           <div>
             <div className="heading">
               <StaticAppBar {...this.props} />
@@ -887,7 +888,14 @@ class ListSkills extends React.Component {
 ListSkills.propTypes = {
   history: PropTypes.object,
   actions: PropTypes.object,
+  isAdmin: PropTypes.bool,
 };
+
+function mapStateToProps(store) {
+  return {
+    isAdmin: store.app.isAdmin,
+  };
+}
 
 function mapDispatchToProps(dispatch) {
   return {
@@ -896,6 +904,6 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(ListSkills);

--- a/src/components/Admin/ListUser/ListUser.js
+++ b/src/components/Admin/ListUser/ListUser.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import './ListUser.css';
+import { connect } from 'react-redux';
 import $ from 'jquery';
 import PropTypes from 'prop-types';
 import Paper from 'material-ui/Paper';
@@ -18,6 +18,7 @@ import { urls } from '../../../utils';
 import { LocaleProvider } from 'antd';
 import enUS from 'antd/lib/locale-provider/en_US';
 import 'antd/lib/table/style/index.css';
+import './ListUser.css';
 
 const cookies = new Cookies();
 
@@ -25,7 +26,7 @@ const TabPane = Tabs.TabPane;
 
 const Search = Input.Search;
 
-export default class ListUser extends Component {
+class ListUser extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -531,6 +532,7 @@ export default class ListUser extends Component {
   };
 
   render() {
+    const { isAdmin } = this.props;
     const actions = [
       <FlatButton
         key={1}
@@ -588,7 +590,7 @@ export default class ListUser extends Component {
 
     return (
       <div>
-        {cookies.get('showAdmin') === 'true' ? (
+        {isAdmin ? (
           <div>
             <div className="heading">
               <StaticAppBar {...this.props} />
@@ -931,4 +933,16 @@ export default class ListUser extends Component {
 
 ListUser.propTypes = {
   history: PropTypes.object,
+  isAdmin: PropTypes.bool,
 };
+
+function mapStateToProps(store) {
+  return {
+    isAdmin: store.app.isAdmin,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(ListUser);

--- a/src/components/Admin/SystemLogs/SystemLogs.js
+++ b/src/components/Admin/SystemLogs/SystemLogs.js
@@ -1,17 +1,15 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import MenuItem from 'material-ui/MenuItem';
 import DropDownMenu from 'material-ui/DropDownMenu';
 import Paper from 'material-ui/Paper';
 import Tabs from 'antd/lib/tabs';
 import { Spin, Alert } from 'antd';
-import Cookies from 'universal-cookie';
 import * as $ from 'jquery';
 import StaticAppBar from '../../StaticAppBar/StaticAppBar.react';
 import NotFound from '../../NotFound/NotFound.react';
 import { urls } from '../../../utils';
-
-const cookies = new Cookies();
 
 const TabPane = Tabs.TabPane;
 
@@ -95,9 +93,10 @@ class SystemLogs extends React.Component {
       themeForegroundColor,
       themeBackgroundColor,
     } = styles;
+    const { isAdmin } = this.props;
     return (
       <div>
-        {cookies.get('showAdmin') === 'true' ? (
+        {isAdmin ? (
           <div>
             <div className="heading">
               <StaticAppBar {...this.props} />
@@ -214,6 +213,16 @@ class SystemLogs extends React.Component {
 
 SystemLogs.propTypes = {
   history: PropTypes.object,
+  isAdmin: PropTypes.bool,
 };
 
-export default SystemLogs;
+function mapStateToProps(store) {
+  return {
+    isAdmin: store.app.isAdmin,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(SystemLogs);

--- a/src/components/Admin/SystemSettings/SystemSettings.js
+++ b/src/components/Admin/SystemSettings/SystemSettings.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import $ from 'jquery';
-import Cookies from 'universal-cookie';
 import Paper from 'material-ui/Paper';
 import Table from 'antd/lib/table';
 import Tabs from 'antd/lib/tabs';
@@ -10,8 +10,6 @@ import enUS from 'antd/lib/locale-provider/en_US';
 import NotFound from '../../NotFound/NotFound.react';
 import StaticAppBar from '../../StaticAppBar/StaticAppBar.react';
 import { urls } from '../../../utils';
-
-const cookies = new Cookies();
 
 const TabPane = Tabs.TabPane;
 
@@ -101,9 +99,10 @@ class SystemSettings extends Component {
 
   render() {
     const { tabStyle } = styles;
+    const { isAdmin } = this.props;
     return (
       <div>
-        {cookies.get('showAdmin') === 'true' ? (
+        {isAdmin ? (
           <div>
             <div className="heading">
               <StaticAppBar {...this.props} />
@@ -156,6 +155,16 @@ class SystemSettings extends Component {
 
 SystemSettings.propTypes = {
   history: PropTypes.object,
+  isAdmin: PropTypes.bool,
 };
 
-export default SystemSettings;
+function mapStateToProps(store) {
+  return {
+    isAdmin: store.app.isAdmin,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(SystemSettings);

--- a/src/components/BotBuilder/BotBuilderPages/Deploy.js
+++ b/src/components/BotBuilder/BotBuilderPages/Deploy.js
@@ -1,23 +1,31 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import Cookies from 'universal-cookie';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import uiActions from '../../../redux/actions/ui';
-const cookies = new Cookies();
 const api = window.location.protocol + '//' + window.location.host;
 class Deploy extends Component {
   render() {
-    let { group, language, skill, actions } = this.props;
-    let part = ` data-skill=&quot;${skill}&quot; src=&quot;${api}/susi-chatbot.js&quot;`;
-    let code = `
-    &lt;script type=&quot;text/javascript&quot;
-    id=&quot;susi-bot-script&quot; data-userid=&quot;${cookies.get(
-      'uuid',
-    )}&quot; data-group=&quot;${group}&quot; data-language=&quot;${language}&quot;${part}
-    &gt;&lt;/script&gt;
-    `;
+    const { group, language, skill, actions, uuid } = this.props;
+    const part =
+      'data-skill=&quot;' +
+      skill +
+      '&quot; src=&quot;' +
+      api +
+      '/susi-chatbot.js&quot;';
+    const code =
+      '&lt;script type=&quot;text/javascript&quot;' +
+      'id=&quot;susi-bot-script&quot; data-userid=&quot;' +
+      uuid +
+      '&quot; data-group=&quot;' +
+      group +
+      '&quot; data-language=&quot;' +
+      language +
+      '&quot;' +
+      part +
+      '&gt;&lt;/script&gt;';
+
     return (
       <div className="menu-page">
         <h1 style={{ lineHeight: '50px' }}>
@@ -39,7 +47,7 @@ class Deploy extends Component {
                     <CopyToClipboard
                       text={
                         "<script type='text/javascript' id='susi-bot-script' data-userid='" +
-                        cookies.get('uuid') +
+                        uuid +
                         "' data-group='" +
                         group +
                         "' data-language='" +
@@ -80,6 +88,7 @@ Deploy.propTypes = {
   language: PropTypes.string,
   skill: PropTypes.string,
   actions: PropTypes.object,
+  uuid: PropTypes.string,
 };
 
 function mapDispatchToProps(dispatch) {
@@ -88,7 +97,13 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
+function mapStateToProps(store) {
+  return {
+    uuid: store.app.uuid,
+  };
+}
+
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(Deploy);

--- a/src/components/BotBuilder/BotBuilderPages/DesignViews/UIView.js
+++ b/src/components/BotBuilder/BotBuilderPages/DesignViews/UIView.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import * as $ from 'jquery';
-import Cookies from 'universal-cookie';
 import { Grid, Col, Row } from 'react-flexbox-grid';
 import CircularProgress from 'material-ui/CircularProgress';
 import RaisedButton from 'material-ui/RaisedButton';
@@ -14,7 +13,6 @@ import Toggle from 'material-ui/Toggle';
 import ColorPicker from 'material-ui-color-picker';
 import { urls, colors, avatars } from '../../../../utils';
 import TiTick from 'react-icons/lib/ti/tick';
-const cookies = new Cookies();
 let BASE_URL = urls.API_URL;
 let IMAGE_GET_URL = `${BASE_URL}/cms/getImage.png?image=`;
 
@@ -148,10 +146,10 @@ class UIView extends Component {
   };
 
   uploadImageBodyBackground = file => {
-    const { actions } = this.props;
+    const { actions, accessToken } = this.props;
     let form = new FormData();
     form.append('image', file);
-    form.append('access_token', cookies.get('loggedIn'));
+    form.append('access_token', accessToken);
     form.append('image_name', file.name);
     let settings = {
       async: true,
@@ -197,9 +195,9 @@ class UIView extends Component {
   };
 
   uploadImageIcon = file => {
-    const { actions } = this.props;
+    const { actions, accessToken } = this.props;
     let form = new FormData();
-    form.append('access_token', cookies.get('loggedIn'));
+    form.append('access_token', accessToken);
     form.append('image_name', file.name);
     form.append('image', file);
     let settings = {
@@ -751,7 +749,14 @@ class UIView extends Component {
 UIView.propTypes = {
   design: PropTypes.object,
   actions: PropTypes.object,
+  accessToken: PropTypes.string,
 };
+
+function mapStateToProps(store) {
+  return {
+    accessToken: store.app.accessToken,
+  };
+}
 
 function mapDispatchToProps(dispatch) {
   return {
@@ -760,6 +765,6 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(UIView);

--- a/src/components/BotBuilder/BotBuilderWrap.js
+++ b/src/components/BotBuilder/BotBuilderWrap.js
@@ -1,12 +1,22 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { Route } from 'react-router-dom';
-import Cookies from 'universal-cookie';
+import PropTypes from 'prop-types';
 import BotBuilder from './BotBuilder';
 import BotWizard from './BotWizard';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import './BotBuilder.css';
 
-const cookies = new Cookies();
+const styles = {
+  loggedInError: {
+    textAlign: 'center',
+    textTransform: 'uppercase',
+    fontWeight: 'bold',
+    marginBottom: '100px',
+    fontSize: '50px',
+    marginTop: '300px',
+  },
+};
 
 const templates = [
   {
@@ -36,13 +46,15 @@ const templates = [
 ];
 
 const BotBuilderWrap = props => {
+  const { accessToken } = props;
+  const { loggedInError } = styles;
   document.title = 'SUSI.AI - Botbuilder';
-  if (!cookies.get('loggedIn')) {
+  if (!accessToken) {
     return (
       <div>
         <StaticAppBar {...props} />
         <div>
-          <p style={styles.loggedInError}>Please login to create a chatbot.</p>
+          <p style={loggedInError}>Please login to create a chatbot.</p>
         </div>
       </div>
     );
@@ -63,14 +75,17 @@ const BotBuilderWrap = props => {
   );
 };
 
-const styles = {
-  loggedInError: {
-    textAlign: 'center',
-    textTransform: 'uppercase',
-    fontWeight: 'bold',
-    marginBottom: '100px',
-    fontSize: '50px',
-    marginTop: '300px',
-  },
+BotBuilderWrap.propTypes = {
+  accessToken: PropTypes.string,
 };
-export default BotBuilderWrap;
+
+function mapStateToProps(store) {
+  return {
+    accessToken: store.app.accessToken,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(BotBuilderWrap);

--- a/src/components/BotBuilder/BotWizard.js
+++ b/src/components/BotBuilder/BotWizard.js
@@ -21,10 +21,57 @@ import ChevronRight from 'material-ui/svg-icons/navigation/chevron-right';
 import { urls, colors, avatars } from '../../utils';
 import Icon from 'antd/lib/icon';
 import * as $ from 'jquery';
-import Cookies from 'universal-cookie';
 import './BotBuilder.css';
 
-const cookies = new Cookies();
+const styles = {
+  home: {
+    width: '100%',
+  },
+  mainPage: {
+    paddingTop: '25px',
+    paddingRight: '15px',
+  },
+  bg: {
+    textAlign: 'center',
+    padding: '30px',
+  },
+  paperStyle: {
+    width: '100%',
+    marginTop: '20px',
+    position: 'relative',
+  },
+  tabStyle: {
+    color: 'rgb(91, 91, 91)',
+  },
+  loggedInError: {
+    textAlign: 'center',
+    textTransform: 'uppercase',
+    fontWeight: 'bold',
+    marginBottom: '100px',
+    fontSize: '50px',
+    marginTop: '300px',
+  },
+  chevron: {
+    position: 'absolute',
+    left: '0',
+    top: '0',
+    width: '35px',
+    height: '35px',
+    color: 'rgb(158, 158, 158)',
+    cursor: 'pointer',
+    display: window.innerWidth < 769 ? 'none' : 'inherit',
+  },
+  chevronButton: {
+    position: 'absolute',
+    left: '4px',
+    top: '4px',
+    width: '35px',
+    height: '35px',
+    color: 'white',
+    cursor: 'pointer',
+    display: window.innerWidth < 769 ? 'none' : 'inherit',
+  },
+};
 
 class BotWizard extends React.Component {
   componentDidMount() {
@@ -153,7 +200,7 @@ class BotWizard extends React.Component {
   };
 
   getDraftBotDetails = id => {
-    const { actions } = this.props;
+    const { actions, accessToken } = this.props;
     let url = urls.API_URL + '/cms/readDraft.json?id=' + id;
     $.ajax({
       url: url,
@@ -176,11 +223,9 @@ class BotWizard extends React.Component {
             'images/<image_name_contact>',
           ];
           if (!localImages.includes(imageNameMatch[1])) {
-            imagePreviewUrl = `${
-              urls.API_URL
-            }/cms/getImage.png?access_token=${cookies.get(
-              'loggedIn',
-            )}&language=${skillLanguage}&group=${skillGroup}&image=${
+            imagePreviewUrl = `${urls.API_URL}/cms/getImage.png?access_token=
+            ${accessToken}
+            &language=${skillLanguage}&group=${skillGroup}&image=${
               imageNameMatch[1]
             }`;
           } else if (imageNameMatch[1] === 'images/<image_name_event>') {
@@ -249,13 +294,13 @@ class BotWizard extends React.Component {
   };
 
   getBotDetails = (name, group, language) => {
-    const { actions } = this.props;
+    const { actions, accessToken } = this.props;
     let url;
     url =
       urls.API_URL +
       // eslint-disable-next-line
       `/cms/getSkill.json?group=${group}&language=${language}&skill=${name}&private=1&access_token=` +
-      cookies.get('loggedIn');
+      accessToken;
     $.ajax({
       url: url,
       dataType: 'jsonp',
@@ -281,11 +326,16 @@ class BotWizard extends React.Component {
           'images/<image_name_contact>',
         ];
         if (!localImages.includes(imageNameMatch[1])) {
-          imagePreviewUrl = `${
-            urls.API_URL
-          }/cms/getImage.png?access_token=${cookies.get(
-            'loggedIn',
-          )}&language=${language}&group=${group}&image=${imageNameMatch[1]}`;
+          imagePreviewUrl =
+            urls.API_URL +
+            '/cms/getImage.png?access_token=' +
+            accessToken +
+            '&language=' +
+            language +
+            '&group=' +
+            group +
+            '&image=' +
+            imageNameMatch[1];
         } else if (imageNameMatch[1] === 'images/<image_name_event>') {
           imagePreviewUrl = '/botTemplates/event-registration.jpg';
         } else if (imageNameMatch[1] === 'images/<image_name_job>') {
@@ -515,12 +565,13 @@ class BotWizard extends React.Component {
 
   saveClick = () => {
     // save the skill on the server
+    const { email, accessToken } = this.props;
     let self = this;
     let code = this.state.buildCode;
     code = self.state.configCode + '\n' + self.state.designCode + '\n' + code;
-    code = '::author_email ' + cookies.get('emailId') + '\n' + code;
+    code = '::author_email ' + email + '\n' + code;
     code = '::protected Yes\n' + code;
-    if (!cookies.get('loggedIn')) {
+    if (!accessToken) {
       notification.open({
         message: 'Not logged In',
         description: 'Please login and then try to create/edit a skill',
@@ -587,7 +638,7 @@ class BotWizard extends React.Component {
       form.append('image', '');
     }
     form.append('content', code);
-    form.append('access_token', cookies.get('loggedIn'));
+    form.append('access_token', accessToken);
     form.append('private', '1');
 
     let settings = {
@@ -668,7 +719,8 @@ class BotWizard extends React.Component {
   };
 
   render() {
-    if (!cookies.get('loggedIn')) {
+    const { accessToken } = this.props;
+    if (!accessToken) {
       return (
         <div>
           <StaticAppBar {...this.props} />
@@ -894,59 +946,19 @@ class BotWizard extends React.Component {
   }
 }
 
-const styles = {
-  home: {
-    width: '100%',
-  },
-  mainPage: {
-    paddingTop: '25px',
-    paddingRight: '15px',
-  },
-  bg: {
-    textAlign: 'center',
-    padding: '30px',
-  },
-  paperStyle: {
-    width: '100%',
-    marginTop: '20px',
-    position: 'relative',
-  },
-  tabStyle: {
-    color: 'rgb(91, 91, 91)',
-  },
-  loggedInError: {
-    textAlign: 'center',
-    textTransform: 'uppercase',
-    fontWeight: 'bold',
-    marginBottom: '100px',
-    fontSize: '50px',
-    marginTop: '300px',
-  },
-  chevron: {
-    position: 'absolute',
-    left: '0',
-    top: '0',
-    width: '35px',
-    height: '35px',
-    color: 'rgb(158, 158, 158)',
-    cursor: 'pointer',
-    display: window.innerWidth < 769 ? 'none' : 'inherit',
-  },
-  chevronButton: {
-    position: 'absolute',
-    left: '4px',
-    top: '4px',
-    width: '35px',
-    height: '35px',
-    color: 'white',
-    cursor: 'pointer',
-    display: window.innerWidth < 769 ? 'none' : 'inherit',
-  },
-};
 BotWizard.propTypes = {
   templates: PropTypes.array,
   actions: PropTypes.object,
+  accessToken: PropTypes.string,
+  email: PropTypes.string,
 };
+
+function mapStateToProps(store) {
+  return {
+    email: store.app.email,
+    accessToken: store.app.accessToken,
+  };
+}
 
 function mapDispatchToProps(dispatch) {
   return {
@@ -955,6 +967,6 @@ function mapDispatchToProps(dispatch) {
 }
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(BotWizard);

--- a/src/components/Dashboard/Dashboard.js
+++ b/src/components/Dashboard/Dashboard.js
@@ -1,13 +1,12 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import { Paper } from 'material-ui';
-import Cookies from 'universal-cookie';
 import MySkills from './MySkills';
 import MyRatings from './MyRatings';
 import MyAnalytics from './MyAnalytics';
 import StaticAppBar from '../StaticAppBar/StaticAppBar.react';
 import './Dashboard.css';
-
-const cookies = new Cookies();
 
 const styles = {
   paperStyle: {
@@ -30,9 +29,9 @@ const styles = {
 const { paperStyle, subHeadingStyle, loggedInErrorStyle } = styles;
 
 const Dashboard = props => {
+  const { accessToken } = props;
   document.title = 'SUSI.AI - Dashboard';
-
-  if (!cookies.get('loggedIn')) {
+  if (!accessToken) {
     return (
       <div>
         <StaticAppBar {...props} />
@@ -69,4 +68,17 @@ const Dashboard = props => {
   );
 };
 
-export default Dashboard;
+Dashboard.propTypes = {
+  accessToken: PropTypes.string,
+};
+
+function mapStateToProps(store) {
+  return {
+    accessToken: store.app.accessToken,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(Dashboard);

--- a/src/components/NotFound/NotFound.react.js
+++ b/src/components/NotFound/NotFound.react.js
@@ -1,4 +1,6 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
 import RaisedButton from 'material-ui/RaisedButton';
 import './NotFound.css';
 import LogoImg from '../../images/susi-logo.svg';
@@ -7,14 +9,37 @@ import SignUp from '../Auth/SignUp/SignUp';
 import Dialog from 'material-ui/Dialog';
 import ForgotPassword from '../Auth/ForgotPassword/ForgotPassword';
 import Close from 'material-ui/svg-icons/navigation/close';
-import Cookies from 'universal-cookie';
 
-const cookies = new Cookies();
+const styles = {
+  closingStyle: {
+    position: 'absolute',
+    zIndex: 1200,
+    fill: '#444',
+    width: '26px',
+    height: '26px',
+    right: '10px',
+    top: '10px',
+    cursor: 'pointer',
+  },
+  closingStyleLogin: {
+    position: 'absolute',
+    zIndex: 1200,
+    fill: '#444',
+    width: '26px',
+    height: '26px',
+    right: '10px',
+    top: '10px',
+    cursor: 'pointer',
+  },
+  bodyStyle: {
+    padding: 0,
+    textAlign: 'center',
+  },
+};
 
-export default class NotFound extends Component {
+class NotFound extends Component {
   constructor(props) {
     super(props);
-
     this.state = {
       open: false,
       loginOpen: false,
@@ -35,7 +60,8 @@ export default class NotFound extends Component {
   };
   // Open Login Dialog
   handleLoginOpen = () => {
-    if (cookies.get('loggedIn')) {
+    const { accessToken } = this.props;
+    if (accessToken) {
       window.location = '/';
     } else {
       this.setState({
@@ -59,30 +85,7 @@ export default class NotFound extends Component {
     });
   };
   render() {
-    const closingStyle = {
-      position: 'absolute',
-      zIndex: 1200,
-      fill: '#444',
-      width: '26px',
-      height: '26px',
-      right: '10px',
-      top: '10px',
-      cursor: 'pointer',
-    };
-    const closingStyleLogin = {
-      position: 'absolute',
-      zIndex: 1200,
-      fill: '#444',
-      width: '26px',
-      height: '26px',
-      right: '10px',
-      top: '10px',
-      cursor: 'pointer',
-    };
-    const bodyStyle = {
-      padding: 0,
-      textAlign: 'center',
-    };
+    const { closingStyle, closingStyleLogin, bodyStyle } = styles;
     return (
       <div>
         <div className="container-fluid not-found-banner">
@@ -172,3 +175,18 @@ export default class NotFound extends Component {
     );
   }
 }
+
+NotFound.propTypes = {
+  accessToken: PropTypes.string,
+};
+
+function mapStateToProps(store) {
+  return {
+    accessToken: store.app.accessToken,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(NotFound);

--- a/src/components/SkillFeedbackCard/SkillFeedbackCard.js
+++ b/src/components/SkillFeedbackCard/SkillFeedbackCard.js
@@ -1,7 +1,6 @@
 // Packages
 import React, { Component } from 'react';
 import { Paper } from 'material-ui';
-import Cookies from 'universal-cookie';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
@@ -29,8 +28,6 @@ import EditBtn from 'material-ui/svg-icons/editor/mode-edit';
 import './SkillFeedbackCard.css';
 
 import { parseDate, formatDate } from '../../utils';
-
-const cookies = new Cookies();
 
 const iconButtonElement = (
   <IconButton touch={true} tooltip="More" tooltipPosition="bottom-left">
@@ -120,7 +117,13 @@ class SkillFeedbackCard extends Component {
   };
 
   render() {
-    const { skillFeedbacks, skillTag, language } = this.props;
+    const {
+      skillFeedbacks,
+      skillTag,
+      language,
+      email,
+      accessToken,
+    } = this.props;
     const { errorText, openEditDialog, openDeleteDialog } = this.state;
     const editActions = [
       <FlatButton
@@ -164,8 +167,6 @@ class SkillFeedbackCard extends Component {
     let userAvatarLink = '';
     let userEmail = '';
     let userFeedbackCard = null;
-    let emailId = cookies.get('emailId');
-    let loggedIn = cookies.get('loggedIn');
     let feedbackCards;
     if (skillFeedbacks) {
       feedbackCards = skillFeedbacks.map((data, index) => {
@@ -177,7 +178,7 @@ class SkillFeedbackCard extends Component {
           src: userAvatarLink,
           name: userName === '' ? userEmail : userName,
         };
-        if (loggedIn && emailId && userEmail === emailId) {
+        if (accessToken && email && userEmail === email) {
           userFeedbackCard = (
             <div key={index}>
               <ListItem
@@ -252,7 +253,7 @@ class SkillFeedbackCard extends Component {
         <div className="top-section">
           <h1 className="title">Feedback</h1>
         </div>
-        {loggedIn && !userFeedbackCard ? (
+        {accessToken && !userFeedbackCard ? (
           <div>
             <div className="subTitle">
               {' '}
@@ -337,6 +338,8 @@ SkillFeedbackCard.propTypes = {
   group: PropTypes.string,
   feedback: PropTypes.string,
   actions: PropTypes.object,
+  accessToken: PropTypes.string,
+  email: PropTypes.string,
 };
 
 function mapStateToProps(store) {
@@ -346,6 +349,8 @@ function mapStateToProps(store) {
     skillTag: store.skill.metaData.skillTag,
     feedback: store.skill.feedback,
     skillFeedbacks: store.skill.skillFeedbacks,
+    email: store.app.email,
+    accessToken: store.app.accessToken,
   };
 }
 

--- a/src/components/SkillPage/SkillListing.js
+++ b/src/components/SkillPage/SkillListing.js
@@ -2,7 +2,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import Cookies from 'universal-cookie';
 import ISO6391 from 'iso-639-1';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -35,8 +34,6 @@ import { urls, colors, parseDate, testExample } from '../../utils';
 import { reportSkill } from '../../api';
 
 import './SkillListing.css';
-
-const cookies = new Cookies();
 
 const styles = {
   home: {
@@ -100,9 +97,9 @@ class SkillListing extends Component {
   }
 
   fetchSkillData = () => {
-    const { actions } = this.props;
+    const { actions, accessToken } = this.props;
     actions.getSkillMetaData(this.skillData);
-    if (cookies.get('loggedIn')) {
+    if (accessToken) {
       actions.getUserRating(this.skillData);
     }
     actions.getDateWiseSkillUsage(this.skillData);
@@ -191,7 +188,6 @@ class SkillListing extends Component {
   };
 
   render() {
-    const showAdmin = cookies.get('showAdmin');
     const {
       showDeleteDialog,
       skillExampleCount,
@@ -213,7 +209,7 @@ class SkillListing extends Component {
       skillRatings,
     } = this.props.metaData;
 
-    const { loadingSkill } = this.props;
+    const { loadingSkill, isAdmin, accessToken } = this.props;
 
     const imgUrl = !image
       ? '/favicon-512x512.jpg'
@@ -304,7 +300,7 @@ class SkillListing extends Component {
               )}
             </div>
             <div className="linkButtons">
-              {showAdmin === 'true' && (
+              {isAdmin === 'true' && (
                 <div className="skillDeleteBtn">
                   <FloatingActionButton
                     onClick={this.handleDeleteToggle}
@@ -512,7 +508,7 @@ class SkillListing extends Component {
                           })}
                         </td>
                       </tr>
-                      {cookies.get('loggedIn') && (
+                      {accessToken && (
                         <tr>
                           <td>Report: </td>
                           <td>
@@ -593,11 +589,15 @@ SkillListing.propTypes = {
   loadingSkill: PropTypes.bool,
   openSnack: PropTypes.bool,
   snackMessage: PropTypes.string,
+  accessToken: PropTypes.string,
+  isAdmin: PropTypes.bool,
 };
 
 function mapStateToProps(store) {
   return {
     ...store.skill,
+    isAdmin: store.app.isAdmin,
+    accessToken: store.app.accessToken,
   };
 }
 

--- a/src/components/SkillRating/SkillRatingCard.js
+++ b/src/components/SkillRating/SkillRatingCard.js
@@ -21,15 +21,12 @@ import {
   ResponsiveContainer,
 } from 'recharts';
 import Ratings from 'react-ratings-declarative';
-import Cookies from 'universal-cookie';
 
 // Material-UI
 import { Paper } from 'material-ui';
 
 // CSS
 import './SkillRatingCard.css';
-
-const cookies = new Cookies();
 
 class SkillRatingCard extends Component {
   static propTypes = {
@@ -40,6 +37,7 @@ class SkillRatingCard extends Component {
     ratingsOverTime: PropTypes.array,
     userRating: PropTypes.number,
     actions: PropTypes.object,
+    accessToken: PropTypes.string,
   };
 
   constructor(props) {
@@ -133,7 +131,13 @@ class SkillRatingCard extends Component {
 
   render() {
     const { chartWidth, ratingsOverTimeWidth, offset } = this.state;
-    const { skillTag, userRating, skillRatings, ratingsOverTime } = this.props;
+    const {
+      skillTag,
+      userRating,
+      skillRatings,
+      ratingsOverTime,
+      accessToken,
+    } = this.props;
     const ratings_data = [
       { name: '5.0 ⭐', value: parseInt(skillRatings.fiveStar, 10) || 0 },
       { name: '4.0 ⭐', value: parseInt(skillRatings.fourStar, 10) || 0 },
@@ -147,7 +151,7 @@ class SkillRatingCard extends Component {
           <h1 className="title" id="rating">
             Ratings
           </h1>
-          {cookies.get('loggedIn') && (
+          {accessToken && (
             <div>
               <div className="subTitle">
                 {' '}
@@ -293,6 +297,7 @@ function mapStateToProps(store) {
     skillRatings: store.skill.metaData.skillRatings,
     ratingsOverTime: store.skill.ratingsOverTime,
     userRating: store.skill.userRating,
+    accessToken: store.app.accessToken,
   };
 }
 

--- a/src/redux/reducers/ui.js
+++ b/src/redux/reducers/ui.js
@@ -9,7 +9,7 @@ const defaultState = {
   snackBarProps: {
     isSnackBarOpen: false,
     snackBarMessage: '',
-    snackBarDuration: '',
+    snackBarDuration: null,
   },
 };
 


### PR DESCRIPTION
Fixes #1826 

Changes: 
- Use redux store to get user-related data instead of relying on cookies
- Added tests for redux
- Fix order of styles in component

Surge Deployment Link: https://pr-1926-1-fossasia-susi-skill-cms.surge.sh

