### PR TITLE
Width of dropdowns adjusted

### DIFF
--- a/src/components/BrowseSkill/custom.css
+++ b/src/components/BrowseSkill/custom.css
@@ -81,12 +81,6 @@ div.scrolling-wrapper::-webkit-scrollbar {
 #pagination > div {
     margin-right: 15px;
 }
-div[role=presentation] {
-    width: 256px !important; /* csslint allow: known-properties, important */
-}
-div[role=presentation]>div[role=menu] {
-    max-width: 256px;
-}
 
 @media screen and (max-width: 418px) {
     .metrics-header {


### PR DESCRIPTION
Fixes #1930 

Changes: Removed the fixed width of 256px from the dropdowns.


Screenshots for the change: 
Sort by:
![corrected3](https://user-images.githubusercontent.com/35253743/52623527-8459d380-2ed2-11e9-858f-6c918c1829a8.png)

Page:
![corrected4](https://user-images.githubusercontent.com/35253743/52623585-ace1cd80-2ed2-11e9-86be-264c4078846f.png)

Skills per page:
![corrected5](https://user-images.githubusercontent.com/35253743/52623647-de5a9900-2ed2-11e9-8851-4bd35ad0c1d4.png)



