### PR TITLE
Fixes #1863: Use initializeSkillDataFailure action to update redux state

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -78,10 +78,15 @@ class BrowseSkill extends React.Component {
   componentDidMount() {
     document.title = 'SUSI.AI - Browse Skills';
     const { actions, routeType } = this.props;
-    actions.initializeSkillData().then(() => {
-      this.loadLanguages('All');
-      this.loadGroups();
-    });
+    actions
+      .initializeSkillData()
+      .then(() => {
+        this.loadLanguages('All');
+        this.loadGroups();
+      })
+      .catch(error => {
+        actions.initializeSkillData();
+      });
 
     if (
       routeType ||
@@ -178,12 +183,18 @@ class BrowseSkill extends React.Component {
   loadGroups = () => {
     const { groups } = this.props;
     if (groups.length === 0) {
-      this.props.actions.getGroupOptions();
+      this.props.actions.getGroupOptions().catch(error => {
+        throw new Error('load groups action failed');
+      });
     }
   };
 
   loadLanguages = value => {
-    this.props.actions.getLanguageOptions({ groupValue: value });
+    this.props.actions
+      .getLanguageOptions({ groupValue: value })
+      .catch(error => {
+        throw new Error('load languages action failed');
+      });
   };
 
   loadCards = () => {


### PR DESCRIPTION
Fixes #1863 

Changes: The changes I have made are: 
- [x] Made use of initializeSkillDataFailed in BrowseSkill component
- [x] Throwing and catching meaningful errors from loadGroups and loadLanguage functions.

Surge Deployment Link: https://pr-1940-fossasia-susi-skill-cms.surge.sh
