### PR TITLE
Add option to control accessToken in AJAX helper #1946

### DIFF
--- a/src/helper/ajax.js
+++ b/src/helper/ajax.js
@@ -14,10 +14,11 @@ const obj = {};
       timeout: 30000,
       dataType: 'json',
       crossDomain: true,
+      isTokenRequired: true,
       ...settings,
     };
 
-    if (cookies.get('loggedIn')) {
+    if (cookies.get('loggedIn') && settings.isTokenRequired) {
       payload = {
         // eslint-disable-next-line camelcase
         access_token: cookies.get('loggedIn'),


### PR DESCRIPTION
Fixes #1946

Changes: Added additional check for access_token.

Reason: Currently, if the user is logged in, the helper AJAX method appends access_token to payload. Due to this, if someone is calling external API, unnecessary accessToken is added, which can give error

Demo Link: https://pr-1947-fossasia-susi-web-chat.surge.sh

Thanks to @akshatnitd for helping me out!
