### PR TITLE
Display Forgot Password form snackbar message

### DIFF
--- a/src/components/Auth/ForgotPassword/ForgotPassword.js
+++ b/src/components/Auth/ForgotPassword/ForgotPassword.js
@@ -121,7 +121,7 @@ class ForgotPassword extends Component {
   handleSubmit = event => {
     event.preventDefault();
 
-    const { openSnackBar, actions } = this.props;
+    const { actions } = this.props;
     let { email } = this.state;
     email = email.trim();
     let validEmail = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(email);
@@ -148,16 +148,14 @@ class ForgotPassword extends Component {
             },
             () => {
               if (success) {
-                setTimeout(() => {
-                  this.closeDialog();
-                }, 2000);
+                this.closeDialog();
+                actions.openSnackBar({
+                  snackBarMessage,
+                  snackBarDuration: 4000,
+                });
               }
             },
           );
-          openSnackBar({
-            snackBarMessage,
-            snackBarDuration: 4000,
-          });
         })
         .catch(error => {
           debugger;
@@ -166,12 +164,12 @@ class ForgotPassword extends Component {
             success: false,
           });
           if (error.statusCode === 422) {
-            openSnackBar({
+            actions.openSnackBar({
               snackBarMessage: 'Email does not exist.',
               snackBarDuration: 4000,
             });
           } else {
-            openSnackBar({
+            actions.openSnackBar({
               snackBarMessage: 'Failed. Try Again',
               snackBarDuration: 4000,
             });


### PR DESCRIPTION
Fixes #1956 

Changes:
* A function `openSnackBar` from props was being used in the forgot password component which was not defined. This function was a property of `actions` prop. Corrected this error and display the snackbar now.

* The forgot password modal was closed after a 2-second delay. I removed this delay as there was no need for the user to wait.

Surge Deployment Link: https://pr-1958-fossasia-susi-skill-cms.surge.sh

Screenshots for the change:
![f](https://user-images.githubusercontent.com/27884543/56088393-5b879780-5e9d-11e9-9a7b-a386de0044e0.gif)


