### PR TITLE
Remove reCAPTCHA key constant file #1964

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -1,5 +1,0 @@
-let KEY = {
-  CAPTCHA_KEY: '6Lfl0G0UAAAAAOvzQPfpTKQFguY14Cn7w6fNvRx1',
-};
-
-export default KEY;


### PR DESCRIPTION
Fixes #1964

Changes: After using the same captcha across the susi domain, reCAPTCHA key file needs to be deleted
Surge Deployment Link: https://pr-1964-fossasia-susi-skill-cms.surge.sh
