### PR TITLE
 Enable the checkbox for Show only Reviewed Skills by default

### DIFF
--- a/src/components/BrowseSkill/BrowseSkill.js
+++ b/src/components/BrowseSkill/BrowseSkill.js
@@ -98,7 +98,7 @@ class BrowseSkill extends React.Component {
       routeType ||
       ['category', 'language'].includes(window.location.href.split('/')[3])
     ) {
-      this.loadCards();
+      this.loadCards(true);
     } else {
       this.loadMetricsSkills();
     }
@@ -206,7 +206,7 @@ class BrowseSkill extends React.Component {
       });
   };
 
-  loadCards = () => {
+  loadCards = bool => {
     const { routeType, routeValue } = this.props;
     const {
       languageValue,
@@ -223,7 +223,7 @@ class BrowseSkill extends React.Component {
       applyFilter: true,
       filterName: orderBy,
       filterType: filterType,
-      showReviewedSkills: reviewed,
+      showReviewedSkills: bool ? false : reviewed,
       showStaffPicks: staffPicks,
       searchQuery: searchQuery,
     };
@@ -257,7 +257,9 @@ class BrowseSkill extends React.Component {
       this.props.actions.setSkillsLoading().then(() => this.loadCards());
     }
     if (ratingRefine) {
-      this.props.actions.setStarRatingFilter({ ratingRefine });
+      this.props.actions
+        .setStarRatingFilter({ ratingRefine })
+        .then(this.loadCards());
     } else {
       this.props.actions
         .setStarRatingFilter({ ratingRefine })

--- a/src/redux/reducers/skills.js
+++ b/src/redux/reducers/skills.js
@@ -27,6 +27,7 @@ const defaultState = {
   ratingRefine: null,
   reviewed: false,
   staffPicks: false,
+  reviewedClicked: false,
   // Pagination
   entriesPerPage: 10,
   listPage: 1,
@@ -93,14 +94,28 @@ export default handleActions(
     },
     [actionTypes.SKILLS_GET_SKILL_LIST](state, { payload }) {
       const { filteredData } = payload;
+      let reviewedSkills = filteredData.filter(data => {
+        return data.reviewed ? data : null;
+      });
+      let reviewedSkillsLength = reviewedSkills.length;
+      const { reviewedClicked, reviewed } = state;
+      let reviewedCondition = reviewedClicked === true ? reviewed : false;
       return {
         ...state,
-        skills: filteredData,
+        skills:
+          reviewedClicked === false && reviewedSkillsLength > 0
+            ? reviewedSkills
+            : filteredData,
         loadingSkills: false,
         listOffset: 0,
         listPage: 1,
         entriesPerPage: 10,
+        reviewed:
+          reviewedClicked === false && reviewedSkillsLength > 0
+            ? true
+            : reviewedCondition,
         listSkills: filteredData.slice(0, 10),
+        reviewedClicked: false,
       };
     },
     [actionTypes.SKILLS_SET_VIEWTYPE](state, { payload }) {
@@ -195,6 +210,7 @@ export default handleActions(
       return {
         ...state,
         reviewed,
+        reviewedClicked: true,
         loadingSkills: true,
       };
     },


### PR DESCRIPTION
Fixes #1545 
Changes: The "Show only Reviewed Skills" checkbox is checked if reviewed skill length is greater than 0.
Surge Deployment Link: https://pr-2010-fossasia-susi-skill-cms.surge.sh